### PR TITLE
make `@types/emscripten` a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,12 @@
     "url": "https://github.com/grame-cncm/faustwasm/issues"
   },
   "homepage": "https://github.com/grame-cncm/faustwasm#readme",
+  "dependencies": {
+    "@types/emscripten": "^1.39.5"
+  },
   "devDependencies": {
     "@aws-crypto/sha256-js": "^2.0.1",
     "@shren/faust-ui": "^1.1.9",
-    "@types/emscripten": "^1.39.5",
     "@types/node": "^16.11.7",
     "@types/webmidi": "^2.0.6",
     "dts-bundle-generator": "^6.13.0",


### PR DESCRIPTION
I'm using the `@grame/faustwasm` package in a project, but my build is broken due to typescript issues in `./node_modules/@grame/faustwasm/dist/esm/index.d.ts`:

```
$ npm run build

> NEW_LIB@0.0.0 build
> tsc && npm run build:lib && npm run build:site

node_modules/@grame/faustwasm/src/types.ts:1:34 - error TS2304: Cannot find name 'EmscriptenModuleFactory'.

1 export type FaustModuleFactory = EmscriptenModuleFactory<FaustModule>;
                                   ~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@grame/faustwasm/src/types.ts:3:38 - error TS2304: Cannot find name 'EmscriptenModule'.

3 export interface FaustModule extends EmscriptenModule {
                                       ~~~~~~~~~~~~~~~~

node_modules/@grame/faustwasm/src/types.ts:4:19 - error TS2304: Cannot find name 'ccall'.

4     ccall: typeof ccall;
                    ~~~~~

node_modules/@grame/faustwasm/src/types.ts:5:19 - error TS2304: Cannot find name 'cwrap'.

5     cwrap: typeof cwrap;
                    ~~~~~

node_modules/@grame/faustwasm/src/types.ts:8:26 - error TS2552: Cannot find name 'UTF8ToString'. Did you mean 'toString'?

8     UTF8ToString: typeof UTF8ToString;
                           ~~~~~~~~~~~~

  node_modules/typescript/lib/lib.dom.d.ts:27432:18
    27432 declare function toString(): string;
                           ~~~~~~~~
    'toString' is declared here.

node_modules/@grame/faustwasm/src/types.ts:9:27 - error TS2304: Cannot find name 'UTF16ToString'.

9     UTF16ToString: typeof UTF16ToString;
                            ~~~~~~~~~~~~~

node_modules/@grame/faustwasm/src/types.ts:10:27 - error TS2304: Cannot find name 'UTF32ToString'.

10     UTF32ToString: typeof UTF32ToString;
                             ~~~~~~~~~~~~~

node_modules/@grame/faustwasm/src/types.ts:11:26 - error TS2304: Cannot find name 'stringToUTF8'.

11     stringToUTF8: typeof stringToUTF8;
                            ~~~~~~~~~~~~

node_modules/@grame/faustwasm/src/types.ts:12:27 - error TS2304: Cannot find name 'stringToUTF16'.

12     stringToUTF16: typeof stringToUTF16;
                             ~~~~~~~~~~~~~

node_modules/@grame/faustwasm/src/types.ts:13:27 - error TS2304: Cannot find name 'stringToUTF32'.

13     stringToUTF32: typeof stringToUTF32;
                             ~~~~~~~~~~~~~

node_modules/@grame/faustwasm/src/types.ts:14:26 - error TS2304: Cannot find name 'allocateUTF8'.

14     allocateUTF8: typeof allocateUTF8;
                            ~~~~~~~~~~~~

node_modules/@grame/faustwasm/src/types.ts:15:29 - error TS2304: Cannot find name 'lengthBytesUTF8'.

15     lengthBytesUTF8: typeof lengthBytesUTF8;
                               ~~~~~~~~~~~~~~~

node_modules/@grame/faustwasm/src/types.ts:16:30 - error TS2304: Cannot find name 'lengthBytesUTF16'.

16     lengthBytesUTF16: typeof lengthBytesUTF16;
                                ~~~~~~~~~~~~~~~~

node_modules/@grame/faustwasm/src/types.ts:17:30 - error TS2304: Cannot find name 'lengthBytesUTF32'.

17     lengthBytesUTF32: typeof lengthBytesUTF32;
                                ~~~~~~~~~~~~~~~~

node_modules/@grame/faustwasm/src/types.ts:18:16 - error TS2304: Cannot find name 'FS'.

18     FS: typeof FS;
                  ~~


Found 15 errors in the same file, starting at: node_modules/@grame/faustwasm/src/types.ts:1
```


The built and distributed files in `@grame/faustwasm` include references to `emscripten` types, but they aren't installed with the package so they are nowhere to be found. 

<img width="1440" alt="image" src="https://github.com/grame-cncm/faustwasm/assets/1285131/dd301d3e-53c3-432f-92c8-bead298bedf6">

Sure enough, once I install `@types/emscripten` this issue is solved and I can build with no trouble.

A good rule of thumb is to only include `@types/...` dependencies in `devDependencies`, but in this case, since the types are referenced in the final distribution of the package, it makes sense to include it.