### PR TITLE
Sensors: Refactor code, add AudioWorklet and iOS support

### DIFF
--- a/assets/standalone/index.js
+++ b/assets/standalone/index.js
@@ -25,6 +25,7 @@ const AudioCtx = window.AudioContext || window.webkitAudioContext;
 const audioContext = new AudioCtx({ latencyHint: 0.00001, echoCancellation: false, autoGainControl: false, noiseSuppression: false });
 audioContext.destination.channelInterpretation = "discrete";
 audioContext.suspend();
+$buttonDsp.disabled = true;
 
 /**
  * @param {FaustAudioWorkletNode} faustNode 
@@ -106,17 +107,6 @@ const buildMidiDeviceMenu = async (faustNode) => {
         currentInput.addEventListener("midimessage", handleMidiMessage);
     };
 };
-
-$buttonDsp.disabled = true;
-$buttonDsp.onclick = () => {
-    if (audioContext.state === "running") {
-        $buttonDsp.textContent = "Suspended";
-        audioContext.suspend();
-    } else if (audioContext.state === "suspended") {
-        $buttonDsp.textContent = "Running";
-        audioContext.resume();
-    }
-}
 
 /**
  * Creates a Faust audio node for use in the Web Audio API.
@@ -218,4 +208,18 @@ const createFaustUI = async (faustNode) => {
     else $spanMidiInput.hidden = true;
     $buttonDsp.disabled = false;
     document.title = name;
+    let motionHandlersBound = false;
+    $buttonDsp.onclick = async () => {
+        if (!motionHandlersBound) {
+            await faustNode.listenMotion();
+            motionHandlersBound = true;
+        }
+        if (audioContext.state === "running") {
+            $buttonDsp.textContent = "Suspended";
+            audioContext.suspend();
+        } else if (audioContext.state === "suspended") {
+            $buttonDsp.textContent = "Running";
+            audioContext.resume();
+        }
+    }
 })();

--- a/src/FaustAudioWorkletProcessor.ts
+++ b/src/FaustAudioWorkletProcessor.ts
@@ -126,15 +126,33 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(dependencie
 
             switch (msg.type) {
                 // Sensors messages
-                case "acc": this.propagateAcc(msg.data); break;
-                case "gyr": this.propagateGyr(msg.data); break;
+                case "acc": {
+                    this.propagateAcc(msg.data);
+                    break;
+                }
+                case "gyr": {
+                    this.propagateGyr(msg.data);
+                    break;
+                }
                 // Generic MIDI message
-                case "midi": this.midiMessage(msg.data); break;
+                case "midi": {
+                    this.midiMessage(msg.data);
+                    break;
+                }
                 // Typed MIDI message
-                case "ctrlChange": this.ctrlChange(msg.data[0], msg.data[1], msg.data[2]); break;
-                case "pitchWheel": this.pitchWheel(msg.data[0], msg.data[1]); break;
+                case "ctrlChange": {
+                    this.ctrlChange(msg.data[0], msg.data[1], msg.data[2]);
+                    break;
+                }
+                case "pitchWheel": {
+                    this.pitchWheel(msg.data[0], msg.data[1]);
+                    break;
+                }
                 // Generic data message
-                case "param": this.setParamValue(msg.data.path, msg.data.value); break;
+                case "param": {
+                    this.setParamValue(msg.data.path, msg.data.value);
+                    break;
+                }
                 // Plot handler set on demand
                 case "setPlotHandler": {
                     if (msg.data) {
@@ -179,11 +197,11 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(dependencie
             this.fDSPCode.pitchWheel(channel, wheel);
         }
 
-        protected propagateAcc(event: DeviceMotionEvent) {
-            this.fDSPCode.propagateAcc(event);
+        protected propagateAcc(accelerationIncludingGravity: NonNullable<DeviceMotionEvent["accelerationIncludingGravity"]>) {
+            this.fDSPCode.propagateAcc(accelerationIncludingGravity);
         }
 
-        protected propagateGyr(event: DeviceOrientationEvent) {
+        protected propagateGyr(event: Pick<DeviceOrientationEvent, "alpha" | "beta" | "gamma">) {
             this.fDSPCode.propagateGyr(event);
         }
     }

--- a/src/FaustDspGenerator.ts
+++ b/src/FaustDspGenerator.ts
@@ -6,9 +6,11 @@ import FaustWasmInstantiator from "./FaustWasmInstantiator";
 import { FaustMonoOfflineProcessor, FaustPolyOfflineProcessor, IFaustMonoOfflineProcessor, IFaustPolyOfflineProcessor } from "./FaustOfflineProcessor";
 import { FaustMonoScriptProcessorNode, FaustPolyScriptProcessorNode } from "./FaustScriptProcessorNode";
 import { FaustBaseWebAudioDsp, FaustMonoWebAudioDsp, FaustPolyWebAudioDsp, FaustWebAudioDspVoice, IFaustMonoWebAudioNode, IFaustPolyWebAudioNode, Soundfile, WasmAllocator } from "./FaustWebAudioDsp";
+import SoundfileReader from "./SoundfileReader";
+import FaustSensors from "./FaustSensors";
 import type { IFaustCompiler } from "./FaustCompiler";
 import type { FaustDspFactory, FaustUIDescriptor, FaustDspMeta, FFTUtils, LooseFaustDspFactory, AudioData } from "./types";
-import SoundfileReader from "./SoundfileReader";
+
 
 export interface GeneratorSupportingSoundfiles {
     /**
@@ -253,21 +255,6 @@ export class FaustMonoDspGenerator implements IFaustMonoDspGenerator {
             const instance = await FaustWasmInstantiator.createAsyncMonoDSPInstance(factory);
             const monoDsp = new FaustMonoWebAudioDsp(instance, context.sampleRate, sampleSize, bufferSize, factory.soundfiles);
 
-            // Setup accelerometer and gyroscope handlers
-            if (window.DeviceMotionEvent) {
-                window.addEventListener("devicemotion", (event: DeviceMotionEvent) => { monoDsp.propagateAcc(event) }, true);
-            } else {
-                // Browser doesn't support DeviceMotionEvent
-                console.log("Cannot set accelerometer handler");
-            }
-
-            if (window.DeviceMotionEvent) {
-                window.addEventListener("deviceorientation", (event: DeviceOrientationEvent) => { monoDsp.propagateGyr(event) }, true);
-            } else {
-                // Browser doesn't support DeviceMotionEvent
-                console.log("Cannot set gyroscope handler");
-            }
-
             const sp = context.createScriptProcessor(bufferSize, monoDsp.getNumInputs(), monoDsp.getNumOutputs()) as FaustMonoScriptProcessorNode;
             Object.setPrototypeOf(sp, FaustMonoScriptProcessorNode.prototype);
             sp.init(monoDsp);
@@ -298,6 +285,8 @@ var ${Soundfile.name} = ${Soundfile.toString()}
 var Soundfile = ${Soundfile.name};
 var ${WasmAllocator.name} = ${WasmAllocator.toString()}
 var WasmAllocator = ${WasmAllocator.name};
+var ${FaustSensors.name} = ${FaustSensors.toString()}
+var FaustSensors = ${FaustSensors.name};
 // Put them in dependencies
 const dependencies = {
     FaustBaseWebAudioDsp,
@@ -319,21 +308,6 @@ const dependencies = {
             }
             // Create the AWN
             const node = new FaustMonoAudioWorkletNode(context, processorName, factory, sampleSize);
-
-            // Setup accelerometer and gyroscope handlers
-            if (window.DeviceMotionEvent) {
-                window.addEventListener("devicemotion", (event: DeviceMotionEvent) => { node.propagateAcc(event) }, true);
-            } else {
-                // Browser doesn't support DeviceMotionEvent
-                console.log("Cannot set accelerometer handler");
-            }
-
-            if (window.DeviceMotionEvent) {
-                window.addEventListener("deviceorientation", (event: DeviceOrientationEvent) => { node.propagateGyr(event) }, true);
-            } else {
-                // Browser doesn't support DeviceMotionEvent
-                console.log("Cannot set gyroscope handler");
-            }
 
             return node as SP extends true ? FaustMonoScriptProcessorNode : FaustMonoAudioWorkletNode;
         }
@@ -377,6 +351,8 @@ var ${Soundfile.name} = ${Soundfile.toString()}
 var Soundfile = ${Soundfile.name};
 var ${WasmAllocator.name} = ${WasmAllocator.toString()}
 var WasmAllocator = ${WasmAllocator.name};
+var ${FaustSensors.name} = ${FaustSensors.toString()}
+var FaustSensors = ${FaustSensors.name};
 var FFTUtils = ${fftUtils.toString()}
 // Put them in dependencies
 const dependencies = {
@@ -611,21 +587,6 @@ process = adaptorIns(dsp_code.process) : dsp_code.effect : adaptorOuts;
             const soundfiles = { ...effectFactory?.soundfiles, ...voiceFactory.soundfiles };
             const polyDsp = new FaustPolyWebAudioDsp(instance, context.sampleRate, sampleSize, bufferSize, soundfiles);
 
-            // Setup accelerometer and gyroscope handlers
-            if (window.DeviceMotionEvent) {
-                window.addEventListener("devicemotion", (event: DeviceMotionEvent) => { polyDsp.propagateAcc(event) }, true);
-            } else {
-                // Browser doesn't support DeviceMotionEvent
-                console.log("Cannot set accelerometer handler");
-            }
-
-            if (window.DeviceMotionEvent) {
-                window.addEventListener("deviceorientation", (event: DeviceOrientationEvent) => { polyDsp.propagateGyr(event) }, true);
-            } else {
-                // Browser doesn't support DeviceMotionEvent
-                console.log("Cannot set gyroscope handler");
-            }
-
             const sp = context.createScriptProcessor(bufferSize, polyDsp.getNumInputs(), polyDsp.getNumOutputs()) as FaustPolyScriptProcessorNode;
             Object.setPrototypeOf(sp, FaustPolyScriptProcessorNode.prototype);
             sp.init(polyDsp);
@@ -659,6 +620,8 @@ var ${Soundfile.name} = ${Soundfile.toString()}
 var Soundfile = ${Soundfile.name};
 var ${WasmAllocator.name} = ${WasmAllocator.toString()}
 var WasmAllocator = ${WasmAllocator.name};
+var ${FaustSensors.name} = ${FaustSensors.toString()}
+var FaustSensors = ${FaustSensors.name};
 // Put them in dependencies
 const dependencies = {
     FaustBaseWebAudioDsp,
@@ -680,21 +643,6 @@ const dependencies = {
             }
             // Create the AWN
             const node = new FaustPolyAudioWorkletNode(context, processorName, voiceFactory, mixerModule, voices, sampleSize, effectFactory || undefined);
-
-            // Setup accelerometer and gyroscope handlers
-            if (window.DeviceMotionEvent) {
-                window.addEventListener("devicemotion", (event: DeviceMotionEvent) => { node.propagateAcc(event) }, true);
-            } else {
-                // Browser doesn't support DeviceMotionEvent
-                console.log("Cannot set accelerometer handler");
-            }
-
-            if (window.DeviceMotionEvent) {
-                window.addEventListener("deviceorientation", (event: DeviceOrientationEvent) => { node.propagateGyr(event) }, true);
-            } else {
-                // Browser doesn't support DeviceMotionEvent
-                console.log("Cannot set gyroscope handler");
-            }
 
             return node as SP extends true ? FaustPolyScriptProcessorNode : FaustPolyAudioWorkletNode;
         }

--- a/src/FaustOfflineProcessor.ts
+++ b/src/FaustOfflineProcessor.ts
@@ -81,6 +81,16 @@ export class FaustOfflineProcessor<Poly extends boolean = false> {
 
     destroy() { this.fDSPCode.destroy(); }
 
+    get hasAccInput() { return this.fDSPCode.hasAccInput; }
+    propagateAcc(accelerationIncludingGravity: NonNullable<DeviceMotionEvent["accelerationIncludingGravity"]>) {
+        this.fDSPCode.propagateAcc(accelerationIncludingGravity);
+    }
+
+    get hasGyrInput() { return this.fDSPCode.hasGyrInput; }
+    propagateGyr(event: Pick<DeviceOrientationEvent, "alpha" | "beta" | "gamma">) {
+        this.fDSPCode.propagateGyr(event);
+    }
+
     /**
      * Render frames in an array.
      *

--- a/src/FaustSensors.ts
+++ b/src/FaustSensors.ts
@@ -1,9 +1,4 @@
-﻿
-interface Window {
-    DeviceMotionEvent: DeviceMotionEvent
-}
-
-export interface AccParams {
+﻿export interface AccParams {
     isEnabled: boolean;
     acc: string;
     address: string;
@@ -13,119 +8,37 @@ export interface AccParams {
     label: string;
 }
 
-// Enum describing the axis of the accelerometer or gyroscope
-export enum Axis { x, y, z };
+/** Enum describing the axis of the accelerometer or gyroscope */
+export enum Axis { x, y, z }
 
-/**
- * Function to convert a number to an axis type
- * 
- * @param value : number
- * @returns : axis type
- */
-export function convertToAxis(value: number): Axis {
-    switch (value) {
-        case 0:
-            return Axis.x;
-        case 1:
-            return Axis.y;
-        case 2:
-            return Axis.z;
-        default:
-            console.error("Error: Axis not found value: " + value);
-            return Axis.x;
-    }
-}
+/** Enum describing the curve of the accelerometer */
+export enum Curve { Up, Down, UpDown, DownUp }
 
-// Enum describing the curve of the accelerometer
-export enum Curve { Up, Down, UpDown, DownUp };
-
-/**
- * Function to convert a number to a curve type
- * 
- * @param value : number
- * @returns : curve type
- */
-export function convertToCurve(value: number): Curve {
-    switch (value) {
-        case 0:
-            return Curve.Up;
-        case 1:
-            return Curve.Down;
-        case 2:
-            return Curve.UpDown;
-        case 3:
-            return Curve.DownUp;
-        default:
-            console.error("Error: Curve not found value: " + value);
-            return Curve.Up;
-    }
-}
-
-// Object describing value off accelerometer metadata values
+/** Object describing value off accelerometer metadata values */
 class AccMeta {
     axis: Axis;
     curve: Curve;
     amin: number;
     amid: number;
-    amax: number
+    amax: number;
 }
 
-/***************************************************************************************
-********************  Converter objects use to map acc and Faust value *****************
-****************************************************************************************/
-
-class Range {
+interface Range {
     fLo: number;
     fHi: number;
-
-    constructor(x: number, y: number) {
-        this.fLo = Math.min(x, y);
-        this.fHi = Math.max(x, y);
-    }
-
-    clip(x: number): number {
-        if (x < this.fLo) {
-            return this.fLo
-        } else if (x > this.fHi) {
-            return this.fHi
-        } else {
-            return x;
-        }
-    }
+    clip(x: number): number;
 }
 
 interface InterpolateObject {
     amin: number;
     amax: number;
 }
-
-/**
- * Interpolator class
- */
-class Interpolator {
+interface Interpolator {
     fRange: Range;
     fCoef: number;
     fOffset: number;
-
-    constructor(lo: number, hi: number, v1: number, v2: number) {
-        this.fRange = new Range(lo, hi);
-        if (hi != lo) {
-            // regular case
-            this.fCoef = (v2 - v1) / (hi - lo);
-            this.fOffset = v1 - lo * this.fCoef;
-        } else {
-            // degenerate case, avoids division by zero
-            this.fCoef = 0;
-            this.fOffset = (v1 + v2) / 2;
-        }
-    }
-    returnMappedValue(v: number): number {
-        var x = this.fRange.clip(v);
-        return this.fOffset + x * this.fCoef
-    }
-    getLowHigh(amin: number, amax: number): InterpolateObject {
-        return { amin: this.fRange.fLo, amax: this.fRange.fHi }
-    }
+    returnMappedValue(v: number): number;
+    getLowHigh(amin: number, amax: number): InterpolateObject;
 }
 
 interface InterpolateObject3pt {
@@ -133,189 +46,325 @@ interface InterpolateObject3pt {
     amid: number;
     amax: number;
 }
-
-/**
- * Interpolator3pt class, combine two interpolators
- */
-class Interpolator3pt {
+interface Interpolator3pt {
     fSegment1: Interpolator;
     fSegment2: Interpolator;
     fMid: number;
-
-    constructor(lo: number, mid: number, hi: number, v1: number, vMid: number, v2: number) {
-        this.fSegment1 = new Interpolator(lo, mid, v1, vMid);
-        this.fSegment2 = new Interpolator(mid, hi, vMid, v2);
-        this.fMid = mid;
-    }
-    returnMappedValue(x: number): number {
-        return (x < this.fMid) ? this.fSegment1.returnMappedValue(x) : this.fSegment2.returnMappedValue(x)
-    }
-
-    getMappingValues(amin: number, amid: number, amax: number): InterpolateObject3pt {
-        var lowHighSegment1 = this.fSegment1.getLowHigh(amin, amid);
-        var lowHighSegment2 = this.fSegment2.getLowHigh(amid, amax);
-        return { amin: lowHighSegment1.amin, amid: lowHighSegment2.amin, amax: lowHighSegment2.amax }
-    }
+    returnMappedValue(v: number): number;
+    getMappingValues(amin: number, amid: number, amax: number): InterpolateObject3pt;
 }
 
 /**
  * ValueConverter interface
  */
 interface ValueConverter {
-    uiToFaust: (x: number) => number;
-    faustToUi: (x: number) => number;
+    uiToFaust(x: number): number;
+    faustToUi(x: number): number;
 }
 
 /**
  * UpdatableValueConverter interface
  */
-
 export interface UpdatableValueConverter extends ValueConverter {
     fActive: boolean;
 
-    setMappingValues: (amin: number, amid: number, amax: number, min: number, init: number, max: number) => void;
-    getMappingValues: (amin: number, amid: number, amax: number) => InterpolateObject3pt;
+    setMappingValues(amin: number, amid: number, amax: number, min: number, init: number, max: number): void;
+    getMappingValues(amin: number, amid: number, amax: number): InterpolateObject3pt;
 
-    setActive: (onOff: boolean) => void;
-    getActive: () => boolean;
+    setActive(onOff: boolean): void;
+    getActive(): boolean;
 }
 
-/**
- * UpConverter class, convert accelerometer value to Faust value
- */
-export class UpConverter implements UpdatableValueConverter {
-    fA2F: Interpolator3pt;
-    fF2A: Interpolator3pt;
-    fActive: boolean = true;
 
-    constructor(amin: number, amid: number, amax: number, fmin: number, fmid: number, fmax: number) {
-        this.fA2F = new Interpolator3pt(amin, amid, amax, fmin, fmid, fmax);
-        this.fF2A = new Interpolator3pt(fmin, fmid, fmax, amin, amid, amax);
+
+export default class FaustSensors {
+    /**
+     * Function to convert a number to an axis type
+     * 
+     * @param value number
+     * @returns axis type
+     */
+    static convertToAxis(value: number): Axis {
+        switch (value) {
+            case 0:
+                return Axis.x;
+            case 1:
+                return Axis.y;
+            case 2:
+                return Axis.z;
+            default:
+                console.error("Error: Axis not found value: " + value);
+                return Axis.x;
+        }
+    }
+    /**
+     * Function to convert a number to a curve type
+     * 
+     * @param value number
+     * @returns curve type
+     */
+    static convertToCurve(value: number): Curve {
+        switch (value) {
+            case 0:
+                return Curve.Up;
+            case 1:
+                return Curve.Down;
+            case 2:
+                return Curve.UpDown;
+            case 3:
+                return Curve.DownUp;
+            default:
+                console.error("Error: Curve not found value: " + value);
+                return Curve.Up;
+        }
     }
 
-    uiToFaust(x: number) { return this.fA2F.returnMappedValue(x) }
-    faustToUi(x: number) { return this.fF2A.returnMappedValue(x) };
+    // Converter objects use to map acc and Faust value
+    static _Range: new (x: number, y: number) => Range;
+    static get Range() {
+        if (!this._Range) {
+            this._Range = class {
+                fLo: number;
+                fHi: number;
 
-    setMappingValues(amin: number, amid: number, amax: number, min: number, init: number, max: number): void {
-        this.fA2F = new Interpolator3pt(amin, amid, amax, min, init, max);
-        this.fF2A = new Interpolator3pt(min, init, max, amin, amid, amax);
-    };
+                constructor(x: number, y: number) {
+                    this.fLo = Math.min(x, y);
+                    this.fHi = Math.max(x, y);
+                }
 
-    getMappingValues(amin: number, amid: number, amax: number): InterpolateObject3pt {
-        return this.fA2F.getMappingValues(amin, amid, amax);
-    };
-
-    setActive(onOff: boolean): void { this.fActive = onOff };
-    getActive(): boolean { return this.fActive };
-}
-
-/**
- * DownConverter class, convert accelerometer value to Faust value
- */
-export class DownConverter implements UpdatableValueConverter {
-    fA2F: Interpolator3pt;
-    fF2A: Interpolator3pt;
-    fActive: boolean = true;
-
-    constructor(amin: number, amid: number, amax: number, fmin: number, fmid: number, fmax: number) {
-        this.fA2F = new Interpolator3pt(amin, amid, amax, fmax, fmid, fmin);
-        this.fF2A = new Interpolator3pt(fmin, fmid, fmax, amax, amid, amin);
+                clip(x: number): number {
+                    if (x < this.fLo) return this.fLo;
+                    if (x > this.fHi) return this.fHi;
+                    return x;
+                }
+            };
+        }
+        return this._Range;
     }
 
-    uiToFaust(x: number) { return this.fA2F.returnMappedValue(x) }
-    faustToUi(x: number) { return this.fF2A.returnMappedValue(x) };
+    static _Interpolator: new (lo: number, hi: number, v1: number, v2: number) => Interpolator;
+    /**
+     * Interpolator class
+     */
+    static get Interpolator() {
+        if (!this._Interpolator) {
+            this._Interpolator = class {
+                fRange: Range;
+                fCoef: number;
+                fOffset: number;
 
-    setMappingValues(amin: number, amid: number, amax: number, min: number, init: number, max: number): void {
-        this.fA2F = new Interpolator3pt(amin, amid, amax, max, init, min);
-        this.fF2A = new Interpolator3pt(min, init, max, amax, amid, amin);
-    };
-    getMappingValues(amin: number, amid: number, amax: number): InterpolateObject3pt {
-        return this.fA2F.getMappingValues(amin, amid, amax);
-    };
-
-    setActive(onOff: boolean): void { this.fActive = onOff };
-    getActive(): boolean { return this.fActive };
-}
-
-/**
- * UpDownConverter class, convert accelerometer value to Faust value
- */
-export class UpDownConverter implements UpdatableValueConverter {
-    fA2F: Interpolator3pt;
-    fF2A: Interpolator;
-    fActive: boolean = true;
-
-    constructor(amin: number, amid: number, amax: number, fmin: number, fmid: number, fmax: number) {
-        this.fA2F = new Interpolator3pt(amin, amid, amax, fmin, fmax, fmin);
-        this.fF2A = new Interpolator(fmin, fmax, amin, amax);
+                constructor(lo: number, hi: number, v1: number, v2: number) {
+                    this.fRange = new FaustSensors.Range(lo, hi);
+                    if (hi !== lo) {
+                        // regular case
+                        this.fCoef = (v2 - v1) / (hi - lo);
+                        this.fOffset = v1 - lo * this.fCoef;
+                    } else {
+                        // degenerate case, avoids division by zero
+                        this.fCoef = 0;
+                        this.fOffset = (v1 + v2) / 2;
+                    }
+                }
+                returnMappedValue(v: number): number {
+                    var x = this.fRange.clip(v);
+                    return this.fOffset + x * this.fCoef;
+                }
+                getLowHigh(amin: number, amax: number): InterpolateObject {
+                    return { amin: this.fRange.fLo, amax: this.fRange.fHi };
+                }
+            };
+        }
+        return this._Interpolator;
     }
 
-    uiToFaust(x: number) { return this.fA2F.returnMappedValue(x) }
-    faustToUi(x: number) { return this.fF2A.returnMappedValue(x) };
+    static _Interpolator3pt: new (lo: number, mid: number, hi: number, v1: number, vMid: number, v2: number) => Interpolator3pt;
+    /**
+     * Interpolator3pt class, combine two interpolators
+     */
+    static get Interpolator3pt() {
+        if (!this._Interpolator3pt) {
+            this._Interpolator3pt = class {
 
-    setMappingValues(amin: number, amid: number, amax: number, min: number, init: number, max: number): void {
-        this.fA2F = new Interpolator3pt(amin, amid, amax, min, max, min);
-        this.fF2A = new Interpolator(min, max, amin, amax);
-    };
-    getMappingValues(amin: number, amid: number, amax: number): InterpolateObject3pt {
-        return this.fA2F.getMappingValues(amin, amid, amax);
-    };
+                fSegment1: Interpolator;
+                fSegment2: Interpolator;
+                fMid: number;
 
-    setActive(onOff: boolean): void { this.fActive = onOff };
-    getActive(): boolean { return this.fActive };
-}
+                constructor(lo: number, mid: number, hi: number, v1: number, vMid: number, v2: number) {
+                    this.fSegment1 = new FaustSensors.Interpolator(lo, mid, v1, vMid);
+                    this.fSegment2 = new FaustSensors.Interpolator(mid, hi, vMid, v2);
+                    this.fMid = mid;
+                }
+                returnMappedValue(x: number): number {
+                    return (x < this.fMid) ? this.fSegment1.returnMappedValue(x) : this.fSegment2.returnMappedValue(x);
+                }
 
-/**
- * DownUpConverter class, convert accelerometer value to Faust value
- */
-export class DownUpConverter implements UpdatableValueConverter {
-    fA2F: Interpolator3pt;
-    fF2A: Interpolator;
-    fActive: boolean = true;
+                getMappingValues(amin: number, amid: number, amax: number): InterpolateObject3pt {
+                    var lowHighSegment1 = this.fSegment1.getLowHigh(amin, amid);
+                    var lowHighSegment2 = this.fSegment2.getLowHigh(amid, amax);
+                    return { amin: lowHighSegment1.amin, amid: lowHighSegment2.amin, amax: lowHighSegment2.amax };
+                }
+            }
 
-    constructor(amin: number, amid: number, amax: number, fmin: number, fmid: number, fmax: number) {
-        this.fA2F = new Interpolator3pt(amin, amid, amax, fmax, fmin, fmax);
-        this.fF2A = new Interpolator(fmin, fmax, amin, amax);
+        }
+        return this._Interpolator3pt;
     }
+    static _UpConverter: new (amin: number, amid: number, amax: number, fmin: number, fmid: number, fmax: number) => UpdatableValueConverter;
+    /**
+     * UpConverter class, convert accelerometer value to Faust value
+     */
+    static get UpConverter() {
+        if (!this._UpConverter) {
+            this._UpConverter = class implements UpdatableValueConverter {
 
-    uiToFaust(x: number) { return this.fA2F.returnMappedValue(x) }
-    faustToUi(x: number) { return this.fF2A.returnMappedValue(x) };
+                fA2F: Interpolator3pt;
+                fF2A: Interpolator3pt;
+                fActive: boolean = true;
 
-    setMappingValues(amin: number, amid: number, amax: number, min: number, init: number, max: number): void {
-        this.fA2F = new Interpolator3pt(amin, amid, amax, max, min, max);
-        this.fF2A = new Interpolator(min, max, amin, amax);
-    };
-    getMappingValues(amin: number, amid: number, amax: number): InterpolateObject3pt {
-        return this.fA2F.getMappingValues(amin, amid, amax);
-    };
+                constructor(amin: number, amid: number, amax: number, fmin: number, fmid: number, fmax: number) {
+                    this.fA2F = new FaustSensors.Interpolator3pt(amin, amid, amax, fmin, fmid, fmax);
+                    this.fF2A = new FaustSensors.Interpolator3pt(fmin, fmid, fmax, amin, amid, amax);
+                }
 
-    setActive(onOff: boolean): void { this.fActive = onOff };
-    getActive(): boolean { return this.fActive };
-}
+                uiToFaust(x: number) { return this.fA2F.returnMappedValue(x) }
+                faustToUi(x: number) { return this.fF2A.returnMappedValue(x) }
 
-/**
- * Public function to build the accelerometer handler
- *
- * @param curve : Curve type
- * @param amin : number 
- * @param amid : number 
- * @param amax : number 
- * @param min : number 
- * @param init : number 
- * @param max : number 
- * @returns : UpdatableValueConverter built for the given curve
- */
-export function buildHandler(curve: Curve, amin: number, amid: number, amax: number, min: number, init: number, max: number): UpdatableValueConverter {
-    switch (curve) {
-        case Curve.Up:
-            return new UpConverter(amin, amid, amax, min, init, max);
-        case Curve.Down:
-            return new DownConverter(amin, amid, amax, min, init, max);
-        case Curve.UpDown:
-            return new UpDownConverter(amin, amid, amax, min, init, max);
-        case Curve.DownUp:
-            return new DownUpConverter(amin, amid, amax, min, init, max);
-        default:
-            return new UpConverter(amin, amid, amax, min, init, max);
+                setMappingValues(amin: number, amid: number, amax: number, min: number, init: number, max: number): void {
+                    this.fA2F = new FaustSensors.Interpolator3pt(amin, amid, amax, min, init, max);
+                    this.fF2A = new FaustSensors.Interpolator3pt(min, init, max, amin, amid, amax);
+                }
+
+                getMappingValues(amin: number, amid: number, amax: number): InterpolateObject3pt {
+                    return this.fA2F.getMappingValues(amin, amid, amax);
+                }
+
+                setActive(onOff: boolean): void { this.fActive = onOff }
+                getActive(): boolean { return this.fActive }
+            }
+
+        }
+        return this._UpConverter;
+    }
+    static _DownConverter: new (amin: number, amid: number, amax: number, fmin: number, fmid: number, fmax: number) => UpdatableValueConverter;
+    /**
+     * DownConverter class, convert accelerometer value to Faust value
+     */
+    static get DownConverter() {
+        if (!this._DownConverter) {
+            this._DownConverter = class implements UpdatableValueConverter {
+
+                fA2F: Interpolator3pt;
+                fF2A: Interpolator3pt;
+                fActive: boolean = true;
+
+                constructor(amin: number, amid: number, amax: number, fmin: number, fmid: number, fmax: number) {
+                    this.fA2F = new FaustSensors.Interpolator3pt(amin, amid, amax, fmax, fmid, fmin);
+                    this.fF2A = new FaustSensors.Interpolator3pt(fmin, fmid, fmax, amax, amid, amin);
+                }
+
+                uiToFaust(x: number) { return this.fA2F.returnMappedValue(x) }
+                faustToUi(x: number) { return this.fF2A.returnMappedValue(x) }
+
+                setMappingValues(amin: number, amid: number, amax: number, min: number, init: number, max: number): void {
+                    this.fA2F = new FaustSensors.Interpolator3pt(amin, amid, amax, max, init, min);
+                    this.fF2A = new FaustSensors.Interpolator3pt(min, init, max, amax, amid, amin);
+                }
+                getMappingValues(amin: number, amid: number, amax: number): InterpolateObject3pt {
+                    return this.fA2F.getMappingValues(amin, amid, amax);
+                }
+
+                setActive(onOff: boolean): void { this.fActive = onOff }
+                getActive(): boolean { return this.fActive }
+            }
+
+        }
+        return this._DownConverter;
+    }
+    static _UpDownConverter: new (amin: number, amid: number, amax: number, fmin: number, fmid: number, fmax: number) => UpdatableValueConverter;
+    /**
+     * UpDownConverter class, convert accelerometer value to Faust value
+     */
+    static get UpDownConverter() {
+        if (!this._UpDownConverter) {
+            this._UpDownConverter = class implements UpdatableValueConverter {
+
+                fA2F: Interpolator3pt;
+                fF2A: Interpolator;
+                fActive: boolean = true;
+
+                constructor(amin: number, amid: number, amax: number, fmin: number, fmid: number, fmax: number) {
+                    this.fA2F = new FaustSensors.Interpolator3pt(amin, amid, amax, fmin, fmax, fmin);
+                    this.fF2A = new FaustSensors.Interpolator(fmin, fmax, amin, amax);
+                }
+
+                uiToFaust(x: number) { return this.fA2F.returnMappedValue(x) }
+                faustToUi(x: number) { return this.fF2A.returnMappedValue(x) }
+
+                setMappingValues(amin: number, amid: number, amax: number, min: number, init: number, max: number): void {
+                    this.fA2F = new FaustSensors.Interpolator3pt(amin, amid, amax, min, max, min);
+                    this.fF2A = new FaustSensors.Interpolator(min, max, amin, amax);
+                }
+                getMappingValues(amin: number, amid: number, amax: number): InterpolateObject3pt {
+                    return this.fA2F.getMappingValues(amin, amid, amax);
+                }
+
+                setActive(onOff: boolean): void { this.fActive = onOff }
+                getActive(): boolean { return this.fActive }
+            }
+
+        }
+        return this._UpDownConverter;
+    }
+    /**
+     * DownUpConverter class, convert accelerometer value to Faust value
+     */
+    static _DownUpConverter: new (amin: number, amid: number, amax: number, fmin: number, fmid: number, fmax: number) => UpdatableValueConverter;
+    static get DownUpConverter() {
+        if (!this._DownUpConverter) {
+            this._DownUpConverter = class implements UpdatableValueConverter {
+
+                fA2F: Interpolator3pt;
+                fF2A: Interpolator;
+                fActive: boolean = true;
+
+                constructor(amin: number, amid: number, amax: number, fmin: number, fmid: number, fmax: number) {
+                    this.fA2F = new FaustSensors.Interpolator3pt(amin, amid, amax, fmax, fmin, fmax);
+                    this.fF2A = new FaustSensors.Interpolator(fmin, fmax, amin, amax);
+                }
+
+                uiToFaust(x: number) { return this.fA2F.returnMappedValue(x) }
+                faustToUi(x: number) { return this.fF2A.returnMappedValue(x) }
+
+                setMappingValues(amin: number, amid: number, amax: number, min: number, init: number, max: number): void {
+                    this.fA2F = new FaustSensors.Interpolator3pt(amin, amid, amax, max, min, max);
+                    this.fF2A = new FaustSensors.Interpolator(min, max, amin, amax);
+                }
+                getMappingValues(amin: number, amid: number, amax: number): InterpolateObject3pt {
+                    return this.fA2F.getMappingValues(amin, amid, amax);
+                }
+
+                setActive(onOff: boolean): void { this.fActive = onOff }
+                getActive(): boolean { return this.fActive }
+            }
+        }
+        return this._DownUpConverter;
+    }
+    /**
+     * Public function to build the accelerometer handler
+     *
+     * @returns `UpdatableValueConverter` built for the given curve
+     */
+    static buildHandler(curve: Curve, amin: number, amid: number, amax: number, min: number, init: number, max: number): UpdatableValueConverter {
+        switch (curve) {
+            case Curve.Up:
+                return new FaustSensors.UpConverter(amin, amid, amax, min, init, max);
+            case Curve.Down:
+                return new FaustSensors.DownConverter(amin, amid, amax, min, init, max);
+            case Curve.UpDown:
+                return new FaustSensors.UpDownConverter(amin, amid, amax, min, init, max);
+            case Curve.DownUp:
+                return new FaustSensors.DownUpConverter(amin, amid, amax, min, init, max);
+            default:
+                return new FaustSensors.UpConverter(amin, amid, amax, min, init, max);
+        }
     }
 }

--- a/test/faustlive-wasm/index.js
+++ b/test/faustlive-wasm/index.js
@@ -492,6 +492,7 @@ const activateMonoDSP = (dsp) => {
     }
 
     // Setup UI
+    DSP.listenMotion();
     faustUI = new FaustUI({ ui: DSP.getUI(), root: faustUIRoot });
     faustUI.paramChangeByUI = (path, value) => DSP.setParamValue(path, value);
     DSP.setOutputParamHandler(output_handler);
@@ -519,6 +520,7 @@ const activatePolyDSP = (dsp) => {
     }
 
     // Setup UI
+    DSP.listenMotion();
     faustUI = new FaustUI({ ui: DSP.getUI(), root: faustUIRoot });
     faustUI.paramChangeByUI = (path, value) => DSP.setParamValue(path, value);
     DSP.setOutputParamHandler(output_handler);


### PR DESCRIPTION
- Pack the classes and functions in `FaustSensors.ts` into a single class with static fields for simplifying injecting them to AudioWorklet thread.
   - Note that the enums will be compiled to plain numbers by TypeScript.
- Move `deviceorientation` and `devicemotion` listeners to `listenMotion` method at AudioNode level, they are not called by default and suppose to be called by the host.
  - Adding some special code for iOS13+ to request permissions.
- Example hosts: adding `node.listenMotion()` after a user gesture for supporting iOS13+