### PR TITLE
FAUST_DSP.js in index.html

### DIFF
--- a/assets/standalone/index.html
+++ b/assets/standalone/index.html
@@ -78,7 +78,7 @@
         <div id="div-faust-ui">
         </div>
     </main>
-    <script src="./FAUST_DSP.js"></script>
+    <script src="FAUST_DSP.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Suggesting edit to remove "./" from FAUST_DSP reference as it seems to be breaking the HTML <src> reference in the compiled code