### PR TITLE
FAUST_DSP in template.html

### DIFF
--- a/assets/standalone/template.html
+++ b/assets/standalone/template.html
@@ -11,7 +11,7 @@
             <center><button id="button-dsp">Activate DSP</button></center>
         </span>
     </main>
-    <script src="./FAUST_DSP.js"></script>
+    <script src="FAUST_DSP.js"></script>
     <script>
         (async () => {
 


### PR DESCRIPTION
Suggesting edit to remove "./" from FAUST_DSP reference as it seems to be breaking the HTML <src> reference in the compiled code