### PR TITLE
handle WAM events directly in the audio thread

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "@shren/faust-ui": "^1.1.11",
         "@types/node": "^20.12.7",
         "@types/webmidi": "^2.0.10",
+        "@webaudiomodules/api": "^2.0.0-alpha.6",
+        "@webaudiomodules/sdk-parammgr": "^0.0.13",
         "dts-bundle-generator": "^9.5.1",
         "esbuild": "^0.20.2",
         "typescript": "^5.4.5"
@@ -506,6 +508,18 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/webmidi/-/webmidi-2.1.0.tgz",
       "integrity": "sha512-k898MjEUSHB+6rSeCPQk/kLgie0wgWZ2t78GlWj86HbTQ+XmtbBafYg5LNjn8bVHfItEhPGZPf579Xfc6keV6w==",
+      "dev": true
+    },
+    "node_modules/@webaudiomodules/api": {
+      "version": "2.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@webaudiomodules/api/-/api-2.0.0-alpha.6.tgz",
+      "integrity": "sha512-GFyp7fVgNd26aFlmk7svGWtwrS1PqrwWajR+JDnbF3aSka9TteZbIcKA6lQ1D7gMc+n8h+te69h+zG5DWwYKIw==",
+      "dev": true
+    },
+    "node_modules/@webaudiomodules/sdk-parammgr": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@webaudiomodules/sdk-parammgr/-/sdk-parammgr-0.0.13.tgz",
+      "integrity": "sha512-1KPjO9BlEfBAeMjfZZ6vfq2wOpRI01FHDyk9ZcCtMACciaHZZmeGobWkf4OToZs5kInGm1fN2dwStgQkiMk09Q==",
       "dev": true
     },
     "node_modules/ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "@shren/faust-ui": "^1.1.11",
     "@types/node": "^20.12.7",
     "@types/webmidi": "^2.0.10",
+    "@webaudiomodules/api": "^2.0.0-alpha.6",
+    "@webaudiomodules/sdk-parammgr": "^0.0.13",
     "dts-bundle-generator": "^9.5.1",
     "esbuild": "^0.20.2",
     "typescript": "^5.4.5"


### PR DESCRIPTION
For WAMs, MIDI scheduling with ParamMgr is broken under OfflineAudioContext since MIDI events goes back to the main thread to trigger event listeners which is too slow for offline rendering.
The patch adds a method allowing find the corresponding ParamMgrProcessor and attach an event listener directly in the audio thread.