### PR TITLE
Timestamped events and sub-block compute: a timed_dsp for the web

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "build-types-bundle": "dts-bundle-generator -o dist/cjs-bundle/index.d.ts src/index-bundle.ts --external-imports",
         "format": "prettier --write src",
         "lint": " prettier --check src && eslint src",
+        "test": "npm run build-esm && node --test \"test/unit/*.test.mjs\"",
         "postbuild": "node postbuild.js"
     },
     "repository": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "format": "prettier --write src",
         "lint": " prettier --check src && eslint src",
         "test": "npm run build-esm && node --test \"test/unit/*.test.mjs\"",
+        "measure": "npm run build-esm && node test/timing/measure.mjs",
         "postbuild": "node postbuild.js"
     },
     "repository": {

--- a/src/FaustAudioWorkletNode.ts
+++ b/src/FaustAudioWorkletNode.ts
@@ -251,33 +251,42 @@ export class FaustAudioWorkletNode<
         }
     }
 
-    midiMessage(data: number[] | Uint8Array): void {
+    /**
+     * `time` is AudioContext seconds, the clock `AudioParam` methods take.
+     *
+     * Given one, the processor holds the message until the block that contains
+     * that instant and applies it on the sample rather than at the top of
+     * whichever block the message happened to arrive in. Left out, the message
+     * is applied on arrival, as it always was.
+     */
+    midiMessage(data: number[] | Uint8Array, time?: number): void {
         const cmd = data[0] >> 4;
         const channel = data[0] & 0xf;
         const data1 = data[1];
         const data2 = data[2];
-        if (cmd === 11) this.ctrlChange(channel, data1, data2);
-        else if (cmd === 14) this.pitchWheel(channel, data2 * 128.0 + data1);
+        if (cmd === 11) this.ctrlChange(channel, data1, data2, time);
+        else if (cmd === 14)
+            this.pitchWheel(channel, data2 * 128.0 + data1, time);
         if (cmd === 8 || (cmd === 9 && data2 === 0))
-            this.keyOff(channel, data1, data2);
-        else if (cmd === 9) this.keyOn(channel, data1, data2);
-        else this.port.postMessage({ type: 'midi', data: data });
+            this.keyOff(channel, data1, data2, time);
+        else if (cmd === 9) this.keyOn(channel, data1, data2, time);
+        else this.port.postMessage({ type: 'midi', data: data, time });
     }
 
-    ctrlChange(channel: number, ctrl: number, value: number) {
-        const e = { type: 'ctrlChange', data: [channel, ctrl, value] };
+    ctrlChange(channel: number, ctrl: number, value: number, time?: number) {
+        const e = { type: 'ctrlChange', data: [channel, ctrl, value], time };
         this.port.postMessage(e);
     }
-    pitchWheel(channel: number, wheel: number) {
-        const e = { type: 'pitchWheel', data: [channel, wheel] };
+    pitchWheel(channel: number, wheel: number, time?: number) {
+        const e = { type: 'pitchWheel', data: [channel, wheel], time };
         this.port.postMessage(e);
     }
-    keyOn(channel: number, pitch: number, velocity: number) {
-        const e = { type: 'keyOn', data: [channel, pitch, velocity] };
+    keyOn(channel: number, pitch: number, velocity: number, time?: number) {
+        const e = { type: 'keyOn', data: [channel, pitch, velocity], time };
         this.port.postMessage(e);
     }
-    keyOff(channel: number, pitch: number, velocity: number) {
-        const e = { type: 'keyOff', data: [channel, pitch, velocity] };
+    keyOff(channel: number, pitch: number, velocity: number, time?: number) {
+        const e = { type: 'keyOff', data: [channel, pitch, velocity], time };
         this.port.postMessage(e);
     }
 
@@ -312,15 +321,22 @@ export class FaustAudioWorkletNode<
         });
     }
 
-    setParamValue(path: string, value: number) {
+    /** `time` is AudioContext seconds; see `midiMessage`. */
+    setParamValue(path: string, value: number, time?: number) {
         const resolved = this.fParamAliases[path] || path;
         this.port.postMessage({
             type: 'param',
-            data: { path: resolved, value }
+            data: { path: resolved, value },
+            time
         });
-        // Set value on AudioParam (but this is not used on Processor side for now)
+        // Keep the AudioParam in step, so that `getParamValue` and any
+        // automation scheduled afterwards start from what was just written.
+        // The processor now reads that automation per sample, so the two
+        // routes agree on both the value and the frame; whichever the DSP sees
+        // second is a write of the value it already holds.
         const param = this.parameters.get(resolved);
-        if (param) param.setValueAtTime(value, this.context.currentTime);
+        if (param)
+            param.setValueAtTime(value, time ?? this.context.currentTime);
     }
     getParamValue(path: string) {
         // Get value of AudioParam
@@ -441,13 +457,13 @@ export class FaustPolyAudioWorkletNode
     }
 
     // Public API
-    keyOn(channel: number, pitch: number, velocity: number) {
-        const e = { type: 'keyOn', data: [channel, pitch, velocity] };
+    keyOn(channel: number, pitch: number, velocity: number, time?: number) {
+        const e = { type: 'keyOn', data: [channel, pitch, velocity], time };
         this.port.postMessage(e);
     }
 
-    keyOff(channel: number, pitch: number, velocity: number) {
-        const e = { type: 'keyOff', data: [channel, pitch, velocity] };
+    keyOff(channel: number, pitch: number, velocity: number, time?: number) {
+        const e = { type: 'keyOff', data: [channel, pitch, velocity], time };
         this.port.postMessage(e);
     }
 

--- a/src/FaustAudioWorkletNode.ts
+++ b/src/FaustAudioWorkletNode.ts
@@ -252,15 +252,11 @@ export class FaustAudioWorkletNode<
     }
 
     /**
-     * `time` is in AudioContext seconds, the clock `AudioParam` methods take.
+     * Send a raw MIDI message, decoding it to the typed call it belongs to.
      *
-     * With a time, the processor holds the message until the block containing
-     * that instant and applies it on the exact sample. Without one, it is
-     * applied on arrival.
-     *
-     * A time already in the past is late, not rejected: the message happens at
-     * the top of the next block. `setParamValue` is the exception -- it also
-     * writes an `AudioParam`, and `setValueAtTime` throws on a negative time.
+     * @param time - AudioContext seconds. The message is applied on that exact
+     * sample. Omitted, it is applied on arrival; already past, at the top of
+     * the next block.
      */
     midiMessage(data: number[] | Uint8Array, time?: number): void {
         const cmd = data[0] >> 4;
@@ -325,23 +321,18 @@ export class FaustAudioWorkletNode<
     }
 
     /**
-     * `time` is in AudioContext seconds; see `midiMessage`.
+     * Set a control's value, on the DSP and on the matching `AudioParam`.
      *
-     * Unlike a note, a negative `time` throws instead of arriving late, and
-     * nothing is sent. `AudioParam.setValueAtTime` is what rejects it, which
-     * is why that call comes first.
+     * @param time - AudioContext seconds; see `midiMessage`. A negative time
+     * throws and sends nothing.
      */
     setParamValue(path: string, value: number, time?: number) {
         const resolved = this.fParamAliases[path] || path;
-        // The AudioParam first, because it is the half that can refuse:
-        // `setValueAtTime` throws on a negative or NaN time. Posting first
-        // would leave the DSP holding a value the AudioParam rejected, with
-        // the caller seeing only the exception.
-        //
-        // Both are written so they stay in step: `getParamValue` and any later
-        // automation start from this value. The processor reads that
-        // automation per sample, so message and AudioParam agree on the value
-        // and the frame, and whichever the DSP sees second is a no-op.
+        // The AudioParam first: `setValueAtTime` throws on a negative or NaN
+        // time, and nothing should be sent if it does. Both are written so
+        // `getParamValue` and any later automation start from this value; the
+        // processor reads that automation per sample, so whichever the DSP
+        // sees second is a no-op.
         const param = this.parameters.get(resolved);
         if (param)
             param.setValueAtTime(value, time ?? this.context.currentTime);
@@ -470,8 +461,7 @@ export class FaustPolyAudioWorkletNode
     }
 
     // Public API
-    // `keyOn` and `keyOff` are inherited: the base posts the same message,
-    // which the processor routes to the polyphonic DSP.
+    // `keyOn` and `keyOff` are inherited from the base.
 
     allNotesOff(hard: boolean) {
         const e = { type: 'ctrlChange', data: [0, 123, 0] };

--- a/src/FaustAudioWorkletNode.ts
+++ b/src/FaustAudioWorkletNode.ts
@@ -324,19 +324,25 @@ export class FaustAudioWorkletNode<
     /** `time` is AudioContext seconds; see `midiMessage`. */
     setParamValue(path: string, value: number, time?: number) {
         const resolved = this.fParamAliases[path] || path;
+        // The AudioParam goes first, because it is the half that can refuse:
+        // `setValueAtTime` throws on a negative time and on a NaN. Posting the
+        // message before finding that out would leave the DSP holding a value
+        // the AudioParam never took, with the caller holding an exception and
+        // no way to know the write had already gone.
+        //
+        // Keeping the two in step is the point of writing both: `getParamValue`
+        // and any automation scheduled afterwards start from what was written,
+        // and the processor now reads that automation per sample, so the two
+        // routes agree on the value and on the frame. Whichever the DSP sees
+        // second is a write of what it already holds.
+        const param = this.parameters.get(resolved);
+        if (param)
+            param.setValueAtTime(value, time ?? this.context.currentTime);
         this.port.postMessage({
             type: 'param',
             data: { path: resolved, value },
             time
         });
-        // Keep the AudioParam in step, so that `getParamValue` and any
-        // automation scheduled afterwards start from what was just written.
-        // The processor now reads that automation per sample, so the two
-        // routes agree on both the value and the frame; whichever the DSP sees
-        // second is a write of the value it already holds.
-        const param = this.parameters.get(resolved);
-        if (param)
-            param.setValueAtTime(value, time ?? this.context.currentTime);
     }
     getParamValue(path: string) {
         // Get value of AudioParam
@@ -457,15 +463,8 @@ export class FaustPolyAudioWorkletNode
     }
 
     // Public API
-    keyOn(channel: number, pitch: number, velocity: number, time?: number) {
-        const e = { type: 'keyOn', data: [channel, pitch, velocity], time };
-        this.port.postMessage(e);
-    }
-
-    keyOff(channel: number, pitch: number, velocity: number, time?: number) {
-        const e = { type: 'keyOff', data: [channel, pitch, velocity], time };
-        this.port.postMessage(e);
-    }
+    // `keyOn` and `keyOff` are inherited: the base posts the same message, and
+    // the processor routes it to the polyphonic DSP.
 
     allNotesOff(hard: boolean) {
         const e = { type: 'ctrlChange', data: [0, 123, 0] };

--- a/src/FaustAudioWorkletNode.ts
+++ b/src/FaustAudioWorkletNode.ts
@@ -252,17 +252,15 @@ export class FaustAudioWorkletNode<
     }
 
     /**
-     * `time` is AudioContext seconds, the clock `AudioParam` methods take.
+     * `time` is in AudioContext seconds, the clock `AudioParam` methods take.
      *
-     * Given one, the processor holds the message until the block that contains
-     * that instant and applies it on the sample rather than at the top of
-     * whichever block the message happened to arrive in. Left out, the message
-     * is applied on arrival, as it always was.
+     * With a time, the processor holds the message until the block containing
+     * that instant and applies it on the exact sample. Without one, it is
+     * applied on arrival.
      *
-     * A time that has already gone by is late rather than refused: the message
-     * happens at the top of the next block. `setParamValue` is the exception,
-     * because it writes an `AudioParam` too and `setValueAtTime` throws on a
-     * negative time -- there the caller hears about it.
+     * A time already in the past is late, not rejected: the message happens at
+     * the top of the next block. `setParamValue` is the exception -- it also
+     * writes an `AudioParam`, and `setValueAtTime` throws on a negative time.
      */
     midiMessage(data: number[] | Uint8Array, time?: number): void {
         const cmd = data[0] >> 4;
@@ -327,25 +325,23 @@ export class FaustAudioWorkletNode<
     }
 
     /**
-     * `time` is AudioContext seconds; see `midiMessage`.
+     * `time` is in AudioContext seconds; see `midiMessage`.
      *
-     * Unlike the notes, a negative `time` throws rather than arriving late,
-     * and nothing is sent: it is `AudioParam.setValueAtTime` that refuses it,
-     * and that call is made first for exactly that reason.
+     * Unlike a note, a negative `time` throws instead of arriving late, and
+     * nothing is sent. `AudioParam.setValueAtTime` is what rejects it, which
+     * is why that call comes first.
      */
     setParamValue(path: string, value: number, time?: number) {
         const resolved = this.fParamAliases[path] || path;
-        // The AudioParam goes first, because it is the half that can refuse:
-        // `setValueAtTime` throws on a negative time and on a NaN. Posting the
-        // message before finding that out would leave the DSP holding a value
-        // the AudioParam never took, with the caller holding an exception and
-        // no way to know the write had already gone.
+        // The AudioParam first, because it is the half that can refuse:
+        // `setValueAtTime` throws on a negative or NaN time. Posting first
+        // would leave the DSP holding a value the AudioParam rejected, with
+        // the caller seeing only the exception.
         //
-        // Keeping the two in step is the point of writing both: `getParamValue`
-        // and any automation scheduled afterwards start from what was written,
-        // and the processor now reads that automation per sample, so the two
-        // routes agree on the value and on the frame. Whichever the DSP sees
-        // second is a write of what it already holds.
+        // Both are written so they stay in step: `getParamValue` and any later
+        // automation start from this value. The processor reads that
+        // automation per sample, so message and AudioParam agree on the value
+        // and the frame, and whichever the DSP sees second is a no-op.
         const param = this.parameters.get(resolved);
         if (param)
             param.setValueAtTime(value, time ?? this.context.currentTime);
@@ -474,8 +470,8 @@ export class FaustPolyAudioWorkletNode
     }
 
     // Public API
-    // `keyOn` and `keyOff` are inherited: the base posts the same message, and
-    // the processor routes it to the polyphonic DSP.
+    // `keyOn` and `keyOff` are inherited: the base posts the same message,
+    // which the processor routes to the polyphonic DSP.
 
     allNotesOff(hard: boolean) {
         const e = { type: 'ctrlChange', data: [0, 123, 0] };

--- a/src/FaustAudioWorkletNode.ts
+++ b/src/FaustAudioWorkletNode.ts
@@ -258,6 +258,11 @@ export class FaustAudioWorkletNode<
      * that instant and applies it on the sample rather than at the top of
      * whichever block the message happened to arrive in. Left out, the message
      * is applied on arrival, as it always was.
+     *
+     * A time that has already gone by is late rather than refused: the message
+     * happens at the top of the next block. `setParamValue` is the exception,
+     * because it writes an `AudioParam` too and `setValueAtTime` throws on a
+     * negative time -- there the caller hears about it.
      */
     midiMessage(data: number[] | Uint8Array, time?: number): void {
         const cmd = data[0] >> 4;
@@ -321,7 +326,13 @@ export class FaustAudioWorkletNode<
         });
     }
 
-    /** `time` is AudioContext seconds; see `midiMessage`. */
+    /**
+     * `time` is AudioContext seconds; see `midiMessage`.
+     *
+     * Unlike the notes, a negative `time` throws rather than arriving late,
+     * and nothing is sent: it is `AudioParam.setValueAtTime` that refuses it,
+     * and that call is made first for exactly that reason.
+     */
     setParamValue(path: string, value: number, time?: number) {
         const resolved = this.fParamAliases[path] || path;
         // The AudioParam goes first, because it is the half that can refuse:

--- a/src/FaustAudioWorkletProcessor.ts
+++ b/src/FaustAudioWorkletProcessor.ts
@@ -109,14 +109,36 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
     const kBlockSize = 128;
 
     /**
-     * A timed event with the order it was created in.
+     * A timed event with a tie-break for the frame it lands on.
      *
      * `frame` alone does not order two events on the same sample, and a
      * `keyOff` sorting ahead of the `keyOn` that preceded it would leave a
-     * voice stuck on. Automation carries -1 so it always goes first: it is the
-     * state the block starts from.
+     * voice stuck on. The three sources are ranked the way they ran before
+     * events existed: the automation is the state the block starts from,
+     * sensors were written next, and messages follow in the order the queue
+     * hands them over, which is time order.
      */
     type FaustTimedEventSeq = FaustTimedEvent & { seq: number };
+
+    const kFromAutomation = -2;
+    const kFromSensors = -1;
+
+    /**
+     * When one control's automation stops being a series of edges and starts
+     * being a ramp, and how coarsely a ramp is then followed.
+     *
+     * Every Faust slider is an a-rate AudioParam, so a single
+     * `linearRampToValueAtTime` hands `process` 128 different values for one
+     * control. Treating each of them as an edge means 128 one-frame `compute`
+     * calls a block, each re-running the DSP's whole control section, and 128
+     * messages to the main thread -- for a difference on a slider that nobody
+     * can hear. What sample accuracy is for is the edge: a gate, a trigger, a
+     * switch, which move once or twice in a block and matter to the sample. So
+     * a control that changes more often than this is followed every
+     * `kRampStride` changes instead, and always at its last value.
+     */
+    const kRampChanges = 16;
+    const kRampStride = 16;
 
     const {
         FaustBaseWebAudioDsp,
@@ -195,6 +217,12 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
          * quiet block this is the only allocation it would otherwise make.
          */
         protected fBlockEvents: FaustTimedEventSeq[] = [];
+
+        /**
+         * The frames one control's automation changed on, while that is being
+         * worked out. Reused for the same reason `fBlockEvents` is.
+         */
+        protected fChangedFrames: number[] = [];
 
         protected wamInfo?: { moduleId: string; instanceId: string };
         protected fCommunicator: FaustAudioWorkletProcessorCommunicator;
@@ -282,15 +310,23 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
         }
 
         /**
-         * Read a message's timestamp as a frame on the audio clock.
+         * Read a message's timestamp as a whole frame on the audio clock.
          *
          * Null when it carries none, which means now.
+         *
+         * Both routes end in a rounded, finite number. A fraction would reach
+         * `renderBlock` as a fractional slice count and a channel pointer
+         * halfway through a sample; a NaN or an Infinity is worse, because it
+         * compares false against everything, so it would sit at the head of
+         * the queue for ever with every later event stuck behind it.
          */
         protected messageFrame(msg: FaustMessageTime): number | null {
-            if (typeof msg.frame === 'number') return msg.frame;
-            if (typeof msg.time === 'number')
-                return Math.round(msg.time * sampleRate);
-            return null;
+            const frame = Number.isFinite(msg.frame as number)
+                ? (msg.frame as number)
+                : Number.isFinite(msg.time as number)
+                  ? (msg.time as number) * sampleRate
+                  : null;
+            return frame === null ? null : Math.round(frame);
         }
 
         /**
@@ -298,7 +334,14 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
          *
          * An untimed message is applied on arrival, exactly as it was before
          * this existed: between two blocks, which is the same thing as offset
-         * 0 in the one that follows.
+         * 0 in the one that follows. A throw from one of those escapes the
+         * message handler, as it always did, and costs that message.
+         *
+         * A timed one is different, and has to be caught. It runs from inside
+         * `process`, and the Web Audio spec's answer to a `process` that
+         * throws is to fire `processorerror` and never call the node again --
+         * so one malformed message would silence the device for the rest of
+         * its life.
          */
         protected atTime(msg: FaustMessageTime, apply: () => void) {
             const frame = this.messageFrame(msg);
@@ -306,7 +349,20 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
                 apply();
                 return;
             }
-            const event = { frame, seq: this.fEventSeq++, apply };
+            const event = {
+                frame,
+                seq: this.fEventSeq++,
+                apply: () => {
+                    try {
+                        apply();
+                    } catch (error) {
+                        console.error(
+                            `Faust: a message timed for frame ${frame} threw and was dropped`,
+                            error
+                        );
+                    }
+                }
+            };
             // Insert from the back. A sequencer posts in time order, so the
             // case that matters costs a comparison or two.
             let i = this.fEventQueue.length;
@@ -315,19 +371,90 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
         }
 
         /**
+         * Drop everything still queued.
+         *
+         * A panic -- all notes off, all sound off -- or the end of the DSP's
+         * life has to reach what has not sounded yet as well as what has,
+         * otherwise the notes queued behind it play afterwards, over a device
+         * that was told to be quiet. Events already collected for the block
+         * being rendered have been taken off the queue and still fire; the
+         * flush is about the blocks after this one.
+         */
+        protected flushEvents() {
+            this.fEventQueue.length = 0;
+        }
+
+        /** Whether a controller number is one of the MIDI panic messages. */
+        protected isPanic(ctrl: number) {
+            // 120 all sound off, 121 reset all controllers, 123 all notes off.
+            return ctrl >= 120 && ctrl <= 123;
+        }
+
+        /**
+         * One control's automation for the block, as events.
+         *
+         * A control the block holds through arrives as a single value, and is
+         * only worth an event when it differs from what the DSP already has.
+         * Otherwise every step in the array is an edge the DSP should see on
+         * the frame it happens: reading only `[0]`, as this used to, rounds
+         * every `setValueAtTime` up to the block boundary that follows it, and
+         * loses a `1 -> 0 -> 1` inside one block entirely, which is a gate
+         * that never retriggers.
+         *
+         * A control that changes more often than `kRampChanges` is not making
+         * edges, it is ramping, and is followed at `kRampStride` instead --
+         * see the constant for why.
+         */
+        protected collectAutomation(
+            path: string,
+            automation: Float32Array,
+            events: FaustTimedEventSeq[]
+        ) {
+            const changes = this.fChangedFrames;
+            changes.length = 0;
+            let last = this.paramValuesCache[path];
+            for (let i = 0; i < automation.length; i++) {
+                if (automation[i] === last) continue;
+                last = automation[i];
+                changes.push(i);
+            }
+            if (changes.length === 0) return;
+            const stride = changes.length > kRampChanges ? kRampStride : 1;
+            for (let n = 0; n < changes.length; n += stride) {
+                const frame = changes[n];
+                events.push(this.paramEvent(path, automation[frame], frame));
+            }
+            // Wherever the ramp ended up is where the block leaves the control,
+            // and the DSP has to be left holding it or the next block's
+            // comparison starts from a value that was never written.
+            const lastChange = changes.length - 1;
+            if (lastChange % stride) {
+                const frame = changes[lastChange];
+                events.push(this.paramEvent(path, automation[frame], frame));
+            }
+        }
+
+        protected paramEvent(
+            path: string,
+            value: number,
+            frame: number
+        ): FaustTimedEventSeq {
+            return {
+                frame,
+                seq: kFromAutomation,
+                apply: () => this.setParamValue(path, value)
+            };
+        }
+
+        /**
          * Everything due inside the block starting at `start`.
          *
-         * Two sources meet here. An `AudioParam` hands `process` its whole
-         * automation for the block -- 128 values when the control moves inside
-         * it, one when it holds -- and every step in that array is an edge the
-         * DSP should see on the frame it happens. Reading only `[0]`, as this
-         * used to, rounds every `setValueAtTime` up to the block boundary that
-         * follows it, and loses a `1 -> 0 -> 1` inside one block entirely,
-         * which is a gate that never retriggers. Port messages carry their own
-         * timestamp and wait in the queue until the block that contains them.
+         * Three sources meet here: the automation each `AudioParam` handed
+         * over for this block, whatever the sensors have to say, and the port
+         * messages that were timestamped for a frame inside it.
          *
-         * The result is sorted by frame; on a tie the automation goes first,
-         * and messages follow in the order they were posted.
+         * The result is sorted by frame, and on a tie by where it came from --
+         * the order those three ran in before any of this was timed.
          */
         protected collectEvents(
             parameters: { [key: string]: Float32Array },
@@ -336,28 +463,47 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
             const events = this.fBlockEvents;
             events.length = 0;
             for (const path in parameters) {
-                const automation = parameters[path];
-                // A control the block holds through arrives as a single value,
-                // and is only worth an event when it differs from what the DSP
-                // already has.
-                let last = this.paramValuesCache[path];
-                for (let i = 0; i < automation.length; i++) {
-                    const value = automation[i];
-                    if (value === last) continue;
-                    last = value;
+                this.collectAutomation(path, parameters[path], events);
+            }
+            // Sensor writes used to happen after the parameter read and before
+            // `compute`, so a control that is both an AudioParam and mapped to
+            // an axis took the sensor's value into the block. Keeping them as
+            // an event at frame 0, ranked after the automation, keeps that.
+            if (this.fCommunicator.getNewAccDataAvailable()) {
+                const acc = this.fCommunicator.getAcc();
+                if (acc) {
+                    this.fCommunicator.setNewAccDataAvailable(false);
+                    const { invert, ...data } = acc;
                     events.push({
-                        frame: i,
-                        seq: -1,
-                        apply: () => this.setParamValue(path, value)
+                        frame: 0,
+                        seq: kFromSensors,
+                        apply: () => this.propagateAcc(data, invert)
+                    });
+                }
+            }
+            if (this.fCommunicator.getNewGyrDataAvailable()) {
+                const gyr = this.fCommunicator.getGyr();
+                if (gyr) {
+                    this.fCommunicator.setNewGyrDataAvailable(false);
+                    events.push({
+                        frame: 0,
+                        seq: kFromSensors,
+                        apply: () => this.propagateGyr(gyr)
                     });
                 }
             }
             const end = start + kBlockSize;
+            let ordinal = 0;
             while (this.fEventQueue.length && this.fEventQueue[0].frame < end) {
                 const event = this.fEventQueue.shift() as FaustTimedEventSeq;
                 // A message whose block has already gone by is late rather
-                // than lost: it happens at the top of this one.
+                // than lost: it happens at the top of this one. Several of
+                // them all collapse onto frame 0, so the tie-break has to be
+                // the order they come off the queue -- which is time order --
+                // and not the order they were posted in, or a schedule that
+                // arrived out of order would be replayed out of order.
                 event.frame = Math.max(0, event.frame - start);
+                event.seq = ordinal++;
                 events.push(event);
             }
             if (events.length > 1) {
@@ -376,22 +522,6 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
                 parameters,
                 audioClock.currentFrame
             );
-            if (this.fCommunicator.getNewAccDataAvailable()) {
-                const acc = this.fCommunicator.getAcc();
-                if (acc) {
-                    this.fCommunicator.setNewAccDataAvailable(false);
-                    const { invert, ...data } = acc;
-                    this.propagateAcc(data, invert);
-                }
-            }
-            if (this.fCommunicator.getNewGyrDataAvailable()) {
-                const gyr = this.fCommunicator.getGyr();
-                if (gyr) {
-                    this.fCommunicator.setNewGyrDataAvailable(false);
-                    this.propagateGyr(gyr);
-                }
-            }
-
             return this.fDSPCode.compute(inputs[0], outputs[0], events);
         }
 
@@ -402,14 +532,24 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
             switch (msg.type) {
                 // Generic MIDI message
                 case 'midi': {
-                    this.atTime(msg, () => this.midiMessage(msg.data));
+                    this.atTime(msg, () => {
+                        // A panic arriving as raw bytes means the same thing
+                        // as the typed one below.
+                        if (
+                            msg.data[0] >> 4 === 11 &&
+                            this.isPanic(msg.data[1])
+                        )
+                            this.flushEvents();
+                        this.midiMessage(msg.data);
+                    });
                     break;
                 }
                 // Typed MIDI message
                 case 'ctrlChange': {
-                    this.atTime(msg, () =>
-                        this.ctrlChange(msg.data[0], msg.data[1], msg.data[2])
-                    );
+                    this.atTime(msg, () => {
+                        if (this.isPanic(msg.data[1])) this.flushEvents();
+                        this.ctrlChange(msg.data[0], msg.data[1], msg.data[2]);
+                    });
                     break;
                 }
                 case 'pitchWheel': {
@@ -466,6 +606,9 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
                     break;
                 }
                 case 'instanceClear': {
+                    // Clearing the DSP's state and then playing the notes that
+                    // were queued before it would be the state coming back.
+                    this.flushEvents();
                     this.fDSPCode.instanceClear();
                     break;
                 }
@@ -482,10 +625,15 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
                     break;
                 }
                 case 'stop': {
+                    // What was scheduled belongs to the stretch that was
+                    // stopped; it should not be waiting when the node starts
+                    // again.
+                    this.flushEvents();
                     this.fDSPCode.stop();
                     break;
                 }
                 case 'destroy': {
+                    this.flushEvents();
                     this.port.close();
                     this.fDSPCode.destroy();
                     break;
@@ -642,24 +790,11 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
             else super.midiMessage(data);
         }
 
+        // The base switch already routes 'keyOn' and 'keyOff' through
+        // `this.keyOn` / `this.keyOff`, which are overridden below, so this is
+        // only here to bind `this` for the port listener.
         protected handleMessageAux = (e: MessageEvent) => {
-            // use arrow function for binding
-            const msg = e.data;
-            switch (msg.type) {
-                case 'keyOn':
-                    this.atTime(msg, () =>
-                        this.keyOn(msg.data[0], msg.data[1], msg.data[2])
-                    );
-                    break;
-                case 'keyOff':
-                    this.atTime(msg, () =>
-                        this.keyOff(msg.data[0], msg.data[1], msg.data[2])
-                    );
-                    break;
-                default:
-                    super.handleMessageAux(e);
-                    break;
-            }
+            super.handleMessageAux(e);
         };
 
         // Public API

--- a/src/FaustAudioWorkletProcessor.ts
+++ b/src/FaustAudioWorkletProcessor.ts
@@ -2,6 +2,7 @@ import type { FaustAudioWorkletProcessorCommunicator } from './FaustAudioWorklet
 import type FaustWasmInstantiator from './FaustWasmInstantiator';
 import type {
     FaustBaseWebAudioDsp,
+    FaustTimedEvent,
     FaustWebAudioDspVoice,
     FaustMonoWebAudioDsp,
     FaustPolyWebAudioDsp
@@ -17,6 +18,21 @@ import type {
     AudioWorkletGlobalScope as WamAudioWorkletGlobalScope,
     WamParamMgrSDKBaseModuleScope
 } from '@webaudiomodules/sdk-parammgr';
+
+/**
+ * When a port message should take effect.
+ *
+ * Both fields name the same clock, the one an `AudioParam` is scheduled
+ * against: `time` in AudioContext seconds, `frame` in samples for a sender
+ * that already counts that way. A message carrying neither happens on arrival,
+ * which is what every caller got before this existed.
+ */
+export interface FaustMessageTime {
+    /** AudioContext seconds, as passed to `AudioParam.setValueAtTime` */
+    time?: number;
+    /** The same instant in samples since the context started */
+    frame?: number;
+}
 
 /**
  * Injected in the string to be compiled on AudioWorkletProcessor side
@@ -83,6 +99,25 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
     const { registerProcessor, AudioWorkletProcessor, sampleRate } =
         globalThis as unknown as AudioWorkletGlobalScope;
 
+    // `currentFrame` is the audio clock in samples. It advances by a block
+    // between calls to `process`, so unlike `sampleRate` it has to be read at
+    // call time rather than destructured once.
+    const audioClock = globalThis as unknown as AudioWorkletGlobalScope;
+
+    // The render quantum, fixed by the Web Audio API and by the buffer size
+    // the DSPs below are constructed with.
+    const kBlockSize = 128;
+
+    /**
+     * A timed event with the order it was created in.
+     *
+     * `frame` alone does not order two events on the same sample, and a
+     * `keyOff` sorting ahead of the `keyOn` that preceded it would leave a
+     * voice stuck on. Automation carries -1 so it always goes first: it is the
+     * state the block starts from.
+     */
+    type FaustTimedEventSeq = FaustTimedEvent & { seq: number };
+
     const {
         FaustBaseWebAudioDsp,
         FaustWasmInstantiator,
@@ -141,6 +176,25 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
             : FaustMonoWebAudioDsp;
 
         protected paramValuesCache: Record<string, number> = {};
+
+        /**
+         * Port messages waiting for the block they were timestamped for.
+         *
+         * Kept sorted by frame and then by arrival, so two events landing on
+         * the same sample happen in the order they were posted. `process`
+         * drains everything up to the end of the block it is about to render;
+         * anything further out waits for its own block.
+         */
+        protected fEventQueue: FaustTimedEventSeq[] = [];
+        protected fEventSeq = 0;
+
+        /**
+         * The events of the block about to be rendered.
+         *
+         * One array, refilled: `process` runs on the audio thread, and on a
+         * quiet block this is the only allocation it would otherwise make.
+         */
+        protected fBlockEvents: FaustTimedEventSeq[] = [];
 
         protected wamInfo?: { moduleId: string; instanceId: string };
         protected fCommunicator: FaustAudioWorkletProcessorCommunicator;
@@ -227,19 +281,101 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
             };
         }
 
+        /**
+         * Read a message's timestamp as a frame on the audio clock.
+         *
+         * Null when it carries none, which means now.
+         */
+        protected messageFrame(msg: FaustMessageTime): number | null {
+            if (typeof msg.frame === 'number') return msg.frame;
+            if (typeof msg.time === 'number')
+                return Math.round(msg.time * sampleRate);
+            return null;
+        }
+
+        /**
+         * Perform `apply` now, or queue it for the frame the sender asked for.
+         *
+         * An untimed message is applied on arrival, exactly as it was before
+         * this existed: between two blocks, which is the same thing as offset
+         * 0 in the one that follows.
+         */
+        protected atTime(msg: FaustMessageTime, apply: () => void) {
+            const frame = this.messageFrame(msg);
+            if (frame === null) {
+                apply();
+                return;
+            }
+            const event = { frame, seq: this.fEventSeq++, apply };
+            // Insert from the back. A sequencer posts in time order, so the
+            // case that matters costs a comparison or two.
+            let i = this.fEventQueue.length;
+            while (i > 0 && this.fEventQueue[i - 1].frame > frame) i--;
+            this.fEventQueue.splice(i, 0, event);
+        }
+
+        /**
+         * Everything due inside the block starting at `start`.
+         *
+         * Two sources meet here. An `AudioParam` hands `process` its whole
+         * automation for the block -- 128 values when the control moves inside
+         * it, one when it holds -- and every step in that array is an edge the
+         * DSP should see on the frame it happens. Reading only `[0]`, as this
+         * used to, rounds every `setValueAtTime` up to the block boundary that
+         * follows it, and loses a `1 -> 0 -> 1` inside one block entirely,
+         * which is a gate that never retriggers. Port messages carry their own
+         * timestamp and wait in the queue until the block that contains them.
+         *
+         * The result is sorted by frame; on a tie the automation goes first,
+         * and messages follow in the order they were posted.
+         */
+        protected collectEvents(
+            parameters: { [key: string]: Float32Array },
+            start: number
+        ) {
+            const events = this.fBlockEvents;
+            events.length = 0;
+            for (const path in parameters) {
+                const automation = parameters[path];
+                // A control the block holds through arrives as a single value,
+                // and is only worth an event when it differs from what the DSP
+                // already has.
+                let last = this.paramValuesCache[path];
+                for (let i = 0; i < automation.length; i++) {
+                    const value = automation[i];
+                    if (value === last) continue;
+                    last = value;
+                    events.push({
+                        frame: i,
+                        seq: -1,
+                        apply: () => this.setParamValue(path, value)
+                    });
+                }
+            }
+            const end = start + kBlockSize;
+            while (this.fEventQueue.length && this.fEventQueue[0].frame < end) {
+                const event = this.fEventQueue.shift() as FaustTimedEventSeq;
+                // A message whose block has already gone by is late rather
+                // than lost: it happens at the top of this one.
+                event.frame = Math.max(0, event.frame - start);
+                events.push(event);
+            }
+            if (events.length > 1) {
+                events.sort((a, b) => a.frame - b.frame || a.seq - b.seq);
+            }
+            return events;
+        }
+
         process(
             inputs: Float32Array[][],
             outputs: Float32Array[][],
             parameters: { [key: string]: Float32Array }
         ) {
-            // Update controls (possibly needed for sample accurate control)
-            for (const path in parameters) {
-                const [paramValue] = parameters[path];
-                if (paramValue !== this.paramValuesCache[path]) {
-                    // Set value and update the cache
-                    this.setParamValue(path, paramValue);
-                }
-            }
+            // Update controls, on the frame each change was scheduled for
+            const events = this.collectEvents(
+                parameters,
+                audioClock.currentFrame
+            );
             if (this.fCommunicator.getNewAccDataAvailable()) {
                 const acc = this.fCommunicator.getAcc();
                 if (acc) {
@@ -256,7 +392,7 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
                 }
             }
 
-            return this.fDSPCode.compute(inputs[0], outputs[0]);
+            return this.fDSPCode.compute(inputs[0], outputs[0], events);
         }
 
         protected handleMessageAux(e: MessageEvent) {
@@ -266,29 +402,39 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
             switch (msg.type) {
                 // Generic MIDI message
                 case 'midi': {
-                    this.midiMessage(msg.data);
+                    this.atTime(msg, () => this.midiMessage(msg.data));
                     break;
                 }
                 // Typed MIDI message
                 case 'ctrlChange': {
-                    this.ctrlChange(msg.data[0], msg.data[1], msg.data[2]);
+                    this.atTime(msg, () =>
+                        this.ctrlChange(msg.data[0], msg.data[1], msg.data[2])
+                    );
                     break;
                 }
                 case 'pitchWheel': {
-                    this.pitchWheel(msg.data[0], msg.data[1]);
+                    this.atTime(msg, () =>
+                        this.pitchWheel(msg.data[0], msg.data[1])
+                    );
                     break;
                 }
                 case 'keyOn': {
-                    this.keyOn(msg.data[0], msg.data[1], msg.data[2]);
+                    this.atTime(msg, () =>
+                        this.keyOn(msg.data[0], msg.data[1], msg.data[2])
+                    );
                     break;
                 }
                 case 'keyOff': {
-                    this.keyOff(msg.data[0], msg.data[1], msg.data[2]);
+                    this.atTime(msg, () =>
+                        this.keyOff(msg.data[0], msg.data[1], msg.data[2])
+                    );
                     break;
                 }
                 // Generic data message
                 case 'param': {
-                    this.setParamValue(msg.data.path, msg.data.value);
+                    this.atTime(msg, () =>
+                        this.setParamValue(msg.data.path, msg.data.value)
+                    );
                     break;
                 }
                 // Plot handler set on demand
@@ -501,10 +647,14 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
             const msg = e.data;
             switch (msg.type) {
                 case 'keyOn':
-                    this.keyOn(msg.data[0], msg.data[1], msg.data[2]);
+                    this.atTime(msg, () =>
+                        this.keyOn(msg.data[0], msg.data[1], msg.data[2])
+                    );
                     break;
                 case 'keyOff':
-                    this.keyOff(msg.data[0], msg.data[1], msg.data[2]);
+                    this.atTime(msg, () =>
+                        this.keyOff(msg.data[0], msg.data[1], msg.data[2])
+                    );
                     break;
                 default:
                     super.handleMessageAux(e);

--- a/src/FaustAudioWorkletProcessor.ts
+++ b/src/FaustAudioWorkletProcessor.ts
@@ -303,8 +303,12 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
             if (!paramMgrProcessor) return;
             if (paramMgrProcessor.handleEvent) return;
             paramMgrProcessor.handleEvent = (event) => {
+                // A WamEvent's `time` is AudioContext seconds, the same clock
+                // a timestamped port message uses, so it goes through the same
+                // queue. A host that sends none gets what it always got: the
+                // message applied on arrival.
                 if (event.type === 'wam-midi')
-                    this.midiMessage(event.data.bytes);
+                    this.atTime(event, () => this.midiMessage(event.data.bytes));
             };
         }
 

--- a/src/FaustAudioWorkletProcessor.ts
+++ b/src/FaustAudioWorkletProcessor.ts
@@ -22,10 +22,9 @@ import type {
 /**
  * When a port message should take effect.
  *
- * Both fields name the same clock, the one an `AudioParam` is scheduled
+ * Both fields are on the audio clock, the one `AudioParam` is scheduled
  * against: `time` in AudioContext seconds, `frame` in samples for a sender
- * that already counts that way. A message carrying neither happens on arrival,
- * which is what every caller got before this existed.
+ * that already counts in samples. Neither field means "on arrival".
  */
 export interface FaustMessageTime {
     /** AudioContext seconds, as passed to `AudioParam.setValueAtTime` */
@@ -99,46 +98,45 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
     const { registerProcessor, AudioWorkletProcessor, sampleRate } =
         globalThis as unknown as AudioWorkletGlobalScope;
 
-    // `currentFrame` is the audio clock in samples. It advances by a block
-    // between calls to `process`, so unlike `sampleRate` it has to be read at
-    // call time rather than destructured once.
+    // `currentFrame` is the audio clock in samples. It advances every
+    // `process` call, so it must be read then, not destructured once.
     const audioClock = globalThis as unknown as AudioWorkletGlobalScope;
 
-    // The render quantum, fixed by the Web Audio API and by the buffer size
-    // the DSPs below are constructed with.
+    // The render quantum, fixed by the Web Audio API and matching the buffer
+    // size the DSPs below are constructed with.
     const kBlockSize = 128;
 
     /**
-     * A timed event with a tie-break for the frame it lands on.
+     * A timed event, plus a tie-break for events sharing a frame.
      *
-     * `frame` alone does not order two events on the same sample, and a
-     * `keyOff` sorting ahead of the `keyOn` that preceded it would leave a
-     * voice stuck on. The three sources are ranked the way they ran before
-     * events existed: the automation is the state the block starts from,
-     * sensors were written next, and messages follow in the order the queue
-     * hands them over, which is time order.
+     * Frame alone leaves two events on the same sample unordered, and a
+     * `keyOff` sorting ahead of its own `keyOn` leaves a voice stuck on. The
+     * ranking is the order these three ran in before any of them were timed:
+     * automation first, as the state the block starts from, then sensors, then
+     * messages in the order the queue hands them over.
      */
     type FaustTimedEventSeq = FaustTimedEvent & { seq: number };
 
     const kFromAutomation = -2;
     const kFromSensors = -1;
 
-    /** What a cancelled event does with its turn. */
+    /** Stands in for the `apply` of a cancelled event. */
     const kCancelled = () => {};
 
     /**
-     * When one control's automation stops being a series of edges and starts
-     * being a ramp, and how coarsely a ramp is then followed.
+     * Where a control stops looking like a series of edges and starts looking
+     * like a ramp, and how coarsely a ramp is then followed.
      *
-     * Every Faust slider is an a-rate AudioParam, so a single
-     * `linearRampToValueAtTime` hands `process` 128 different values for one
-     * control. Treating each of them as an edge means 128 one-frame `compute`
-     * calls a block, each re-running the DSP's whole control section, and 128
-     * messages to the main thread -- for a difference on a slider that nobody
-     * can hear. What sample accuracy is for is the edge: a gate, a trigger, a
-     * switch, which move once or twice in a block and matter to the sample. So
-     * a control that changes more often than this is followed every
-     * `kRampStride` changes instead, and always at its last value.
+     * Every Faust slider is an a-rate AudioParam, so one
+     * `linearRampToValueAtTime` gives `process` 128 distinct values for a
+     * single control. Honouring each would mean 128 one-frame `compute` calls
+     * per block, each re-running the DSP's control section, plus 128
+     * `in-param` messages to the main thread.
+     *
+     * Sample accuracy is for edges -- gates, triggers, switches -- which move
+     * once or twice a block. A control that changes more often than
+     * `kRampChanges` is followed every `kRampStride` changes instead, plus the
+     * value it ends the block on.
      */
     const kRampChanges = 16;
     const kRampStride = 16;
@@ -205,10 +203,8 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
         /**
          * Port messages waiting for the block they were timestamped for.
          *
-         * Kept sorted by frame and then by arrival, so two events landing on
-         * the same sample happen in the order they were posted. `process`
-         * drains everything up to the end of the block it is about to render;
-         * anything further out waits for its own block.
+         * Sorted by frame, then by arrival. `process` drains everything up to
+         * the end of the block it is about to render; the rest waits.
          */
         protected fEventQueue: FaustTimedEventSeq[] = [];
         protected fEventSeq = 0;
@@ -216,14 +212,14 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
         /**
          * The events of the block about to be rendered.
          *
-         * One array, refilled: `process` runs on the audio thread, and on a
-         * quiet block this is the only allocation it would otherwise make.
+         * Refilled rather than reallocated, so a quiet block allocates
+         * nothing.
          */
         protected fBlockEvents: FaustTimedEventSeq[] = [];
 
         /**
-         * The frames one control's automation changed on, while that is being
-         * worked out. Reused for the same reason `fBlockEvents` is.
+         * Scratch space for the frames one control's automation changed on.
+         * Reused for the same reason as `fBlockEvents`.
          */
         protected fChangedFrames: number[] = [];
 
@@ -314,14 +310,13 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
 
         /**
          * Read a message's timestamp as a whole frame on the audio clock.
+         * Null if it carries none, meaning now.
          *
-         * Null when it carries none, which means now.
-         *
-         * Both routes end in a rounded, finite number. A fraction would reach
-         * `renderBlock` as a fractional slice count and a channel pointer
-         * halfway through a sample; a NaN or an Infinity is worse, because it
-         * compares false against everything, so it would sit at the head of
-         * the queue for ever with every later event stuck behind it.
+         * Both routes round, and both reject anything non-finite. A fraction
+         * would become a fractional slice count and a channel pointer partway
+         * through a sample. A NaN compares false against every frame, so a
+         * queued one would stay at the head of the queue and block every event
+         * behind it.
          */
         protected messageFrame(msg: FaustMessageTime): number | null {
             const frame = Number.isFinite(msg.frame as number)
@@ -333,18 +328,16 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
         }
 
         /**
-         * Perform `apply` now, or queue it for the frame the sender asked for.
+         * Apply `apply` now, or queue it for the frame the sender asked for.
          *
-         * An untimed message is applied on arrival, exactly as it was before
-         * this existed: between two blocks, which is the same thing as offset
-         * 0 in the one that follows. A throw from one of those escapes the
-         * message handler, as it always did, and costs that message.
+         * Untimed messages are applied on arrival, between two blocks, which
+         * is equivalent to frame 0 of the next one. A throw from one of those
+         * escapes the port handler and costs that message, as it always did.
          *
-         * A timed one is different, and has to be caught. It runs from inside
-         * `process`, and the Web Audio spec's answer to a `process` that
-         * throws is to fire `processorerror` and never call the node again --
-         * so one malformed message would silence the device for the rest of
-         * its life.
+         * Timed ones have to catch. They run from inside `process`, and the
+         * Web Audio spec's response to a `process` that throws is to fire
+         * `processorerror` and stop calling the node -- so one bad message
+         * would silence the device permanently.
          */
         protected atTime(msg: FaustMessageTime, apply: () => void) {
             const frame = this.messageFrame(msg);
@@ -366,8 +359,8 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
                     }
                 }
             };
-            // Insert from the back. A sequencer posts in time order, so the
-            // case that matters costs a comparison or two.
+            // Insert from the back: a sequencer posts in time order, so the
+            // common case is a comparison or two.
             let i = this.fEventQueue.length;
             while (i > 0 && this.fEventQueue[i - 1].frame > frame) i--;
             this.fEventQueue.splice(i, 0, event);
@@ -376,17 +369,14 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
         /**
          * Cancel everything scheduled and not yet performed.
          *
-         * A panic -- all notes off, all sound off -- or the end of the DSP's
-         * life has to reach what has not sounded yet as well as what has,
-         * otherwise the notes queued behind it play afterwards, over a device
-         * that was told to be quiet. That means the queue, and it also means
-         * the rest of the block being rendered: those events have already been
-         * taken off the queue, and a `keyOn` at frame 100 is just as much a
-         * note to cancel as one in the block after this.
+         * A panic, or the end of the DSP's life, has to reach the notes that
+         * have not sounded yet as well as the ones that have -- otherwise they
+         * play afterwards, over a device that was told to be quiet.
          *
-         * Only the messages. The automation and the sensors are the state of
-         * the controls through the block, not notes waiting to sound, and an
-         * all-notes-off is not a reason to stop a filter sweep.
+         * That means the queue and the rest of the block being rendered, whose
+         * events have already left the queue. Messages only: automation and
+         * sensor writes are the state of the controls through the block, and
+         * an all-notes-off should not stop a filter sweep.
          */
         protected flushEvents() {
             this.fEventQueue.length = 0;
@@ -398,9 +388,9 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
         /**
          * Whether a controller number silences the instrument.
          *
-         * The two the polyphonic DSP itself treats as all-notes-off, and no
-         * more: 122 is local control, which is about a keyboard's own wiring,
-         * and 121 resets controllers to their defaults without ending a note.
+         * Exactly the two `FaustPolyWebAudioDsp.ctrlChange` treats as
+         * all-notes-off. Not 121, which resets controllers without ending a
+         * note, and not 122, which is a keyboard's local control.
          */
         protected isPanic(ctrl: number) {
             return ctrl === 120 || ctrl === 123;
@@ -409,17 +399,16 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
         /**
          * One control's automation for the block, as events.
          *
-         * A control the block holds through arrives as a single value, and is
-         * only worth an event when it differs from what the DSP already has.
-         * Otherwise every step in the array is an edge the DSP should see on
-         * the frame it happens: reading only `[0]`, as this used to, rounds
-         * every `setValueAtTime` up to the block boundary that follows it, and
-         * loses a `1 -> 0 -> 1` inside one block entirely, which is a gate
-         * that never retriggers.
+         * A control that holds arrives as a single value, worth an event only
+         * if it differs from what the DSP has. A control that moves arrives as
+         * 128, and each change is an edge due on its own frame.
          *
-         * A control that changes more often than `kRampChanges` is not making
-         * edges, it is ramping, and is followed at `kRampStride` instead --
-         * see the constant for why.
+         * Reading only `[0]`, as this used to, pushes every `setValueAtTime`
+         * out to the next block boundary and misses a `1 -> 0 -> 1` inside one
+         * block completely -- a gate that never retriggers.
+         *
+         * Above `kRampChanges` the control is ramping rather than stepping,
+         * and is followed at `kRampStride`. See the constants.
          */
         protected collectAutomation(
             path: string,
@@ -440,9 +429,8 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
                 const frame = changes[n];
                 events.push(this.paramEvent(path, automation[frame], frame));
             }
-            // Wherever the ramp ended up is where the block leaves the control,
-            // and the DSP has to be left holding it or the next block's
-            // comparison starts from a value that was never written.
+            // Always write the value the block ends on, or the next block
+            // compares against a value the DSP was never given.
             const lastChange = changes.length - 1;
             if (lastChange % stride) {
                 const frame = changes[lastChange];
@@ -465,12 +453,11 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
         /**
          * Everything due inside the block starting at `start`.
          *
-         * Three sources meet here: the automation each `AudioParam` handed
-         * over for this block, whatever the sensors have to say, and the port
-         * messages that were timestamped for a frame inside it.
+         * Three sources: the automation each `AudioParam` handed over, any new
+         * sensor readings, and the port messages timestamped for a frame
+         * inside the block.
          *
-         * The result is sorted by frame, and on a tie by where it came from --
-         * the order those three ran in before any of this was timed.
+         * Sorted by frame, and on a tie by source -- see `FaustTimedEventSeq`.
          */
         protected collectEvents(
             parameters: { [key: string]: Float32Array },
@@ -481,10 +468,10 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
             for (const path in parameters) {
                 this.collectAutomation(path, parameters[path], events);
             }
-            // Sensor writes used to happen after the parameter read and before
+            // Sensor writes used to run after the parameter read and before
             // `compute`, so a control that is both an AudioParam and mapped to
-            // an axis took the sensor's value into the block. Keeping them as
-            // an event at frame 0, ranked after the automation, keeps that.
+            // an axis took the sensor's value. An event at frame 0 ranked
+            // after the automation preserves that.
             if (this.fCommunicator.getNewAccDataAvailable()) {
                 const acc = this.fCommunicator.getAcc();
                 if (acc) {
@@ -512,12 +499,11 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
             let ordinal = 0;
             while (this.fEventQueue.length && this.fEventQueue[0].frame < end) {
                 const event = this.fEventQueue.shift() as FaustTimedEventSeq;
-                // A message whose block has already gone by is late rather
-                // than lost: it happens at the top of this one. Several of
-                // them all collapse onto frame 0, so the tie-break has to be
-                // the order they come off the queue -- which is time order --
-                // and not the order they were posted in, or a schedule that
-                // arrived out of order would be replayed out of order.
+                // A message whose block has passed is late, not lost: it
+                // happens at the top of this one. Several of them collapse
+                // onto frame 0 together, so the tie-break is the order they
+                // come off the queue, which is time order. Posting order would
+                // replay an out-of-order schedule out of order.
                 event.frame = Math.max(0, event.frame - start);
                 event.seq = ordinal++;
                 events.push(event);
@@ -533,7 +519,7 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
             outputs: Float32Array[][],
             parameters: { [key: string]: Float32Array }
         ) {
-            // Update controls, on the frame each change was scheduled for
+            // Controls, each on the frame it was scheduled for
             const events = this.collectEvents(
                 parameters,
                 audioClock.currentFrame
@@ -549,8 +535,7 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
                 // Generic MIDI message
                 case 'midi': {
                     this.atTime(msg, () => {
-                        // A panic arriving as raw bytes means the same thing
-                        // as the typed one below.
+                        // A panic as raw bytes, same as the typed case below
                         if (
                             msg.data[0] >> 4 === 11 &&
                             this.isPanic(msg.data[1])
@@ -622,8 +607,8 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
                     break;
                 }
                 case 'instanceClear': {
-                    // Clearing the DSP's state and then playing the notes that
-                    // were queued before it would be the state coming back.
+                    // Notes queued before the clear would put back the state
+                    // it just cleared.
                     this.flushEvents();
                     this.fDSPCode.instanceClear();
                     break;
@@ -641,9 +626,8 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
                     break;
                 }
                 case 'stop': {
-                    // What was scheduled belongs to the stretch that was
-                    // stopped; it should not be waiting when the node starts
-                    // again.
+                    // What was scheduled belongs to the stretch being
+                    // stopped, and should not still be waiting on restart.
                     this.flushEvents();
                     this.fDSPCode.stop();
                     break;
@@ -807,8 +791,8 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
         }
 
         // The base switch already routes 'keyOn' and 'keyOff' through
-        // `this.keyOn` / `this.keyOff`, which are overridden below, so this is
-        // only here to bind `this` for the port listener.
+        // `this.keyOn` / `this.keyOff`, overridden below. This exists only to
+        // bind `this` for the port listener.
         protected handleMessageAux = (e: MessageEvent) => {
             super.handleMessageAux(e);
         };

--- a/src/FaustAudioWorkletProcessor.ts
+++ b/src/FaustAudioWorkletProcessor.ts
@@ -123,6 +123,9 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
     const kFromAutomation = -2;
     const kFromSensors = -1;
 
+    /** What a cancelled event does with its turn. */
+    const kCancelled = () => {};
+
     /**
      * When one control's automation stops being a series of edges and starts
      * being a ramp, and how coarsely a ramp is then followed.
@@ -371,23 +374,36 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
         }
 
         /**
-         * Drop everything still queued.
+         * Cancel everything scheduled and not yet performed.
          *
          * A panic -- all notes off, all sound off -- or the end of the DSP's
          * life has to reach what has not sounded yet as well as what has,
          * otherwise the notes queued behind it play afterwards, over a device
-         * that was told to be quiet. Events already collected for the block
-         * being rendered have been taken off the queue and still fire; the
-         * flush is about the blocks after this one.
+         * that was told to be quiet. That means the queue, and it also means
+         * the rest of the block being rendered: those events have already been
+         * taken off the queue, and a `keyOn` at frame 100 is just as much a
+         * note to cancel as one in the block after this.
+         *
+         * Only the messages. The automation and the sensors are the state of
+         * the controls through the block, not notes waiting to sound, and an
+         * all-notes-off is not a reason to stop a filter sweep.
          */
         protected flushEvents() {
             this.fEventQueue.length = 0;
+            for (const event of this.fBlockEvents) {
+                if (event.seq >= 0) event.apply = kCancelled;
+            }
         }
 
-        /** Whether a controller number is one of the MIDI panic messages. */
+        /**
+         * Whether a controller number silences the instrument.
+         *
+         * The two the polyphonic DSP itself treats as all-notes-off, and no
+         * more: 122 is local control, which is about a keyboard's own wiring,
+         * and 121 resets controllers to their defaults without ending a note.
+         */
         protected isPanic(ctrl: number) {
-            // 120 all sound off, 121 reset all controllers, 123 all notes off.
-            return ctrl >= 120 && ctrl <= 123;
+            return ctrl === 120 || ctrl === 123;
         }
 
         /**

--- a/src/FaustAudioWorkletProcessor.ts
+++ b/src/FaustAudioWorkletProcessor.ts
@@ -20,11 +20,7 @@ import type {
 } from '@webaudiomodules/sdk-parammgr';
 
 /**
- * When a port message should take effect.
- *
- * Both fields are on the audio clock, the one `AudioParam` is scheduled
- * against: `time` in AudioContext seconds, `frame` in samples for a sender
- * that already counts in samples. Neither field means "on arrival".
+ * When a port message should take effect. Neither field means on arrival.
  */
 export interface FaustMessageTime {
     /** AudioContext seconds, as passed to `AudioParam.setValueAtTime` */
@@ -98,45 +94,28 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
     const { registerProcessor, AudioWorkletProcessor, sampleRate } =
         globalThis as unknown as AudioWorkletGlobalScope;
 
-    // `currentFrame` is the audio clock in samples. It advances every
-    // `process` call, so it must be read then, not destructured once.
+    // Read at call time: `currentFrame` advances every `process` call.
     const audioClock = globalThis as unknown as AudioWorkletGlobalScope;
 
-    // The render quantum, fixed by the Web Audio API and matching the buffer
-    // size the DSPs below are constructed with.
+    // The render quantum, and the buffer size the DSPs are constructed with.
     const kBlockSize = 128;
 
     /**
-     * A timed event, plus a tie-break for events sharing a frame.
-     *
-     * Frame alone leaves two events on the same sample unordered, and a
-     * `keyOff` sorting ahead of its own `keyOn` leaves a voice stuck on. The
-     * ranking is the order these three ran in before any of them were timed:
-     * automation first, as the state the block starts from, then sensors, then
-     * messages in the order the queue hands them over.
+     * A timed event, plus `seq` to order events sharing a frame: automation
+     * first, then sensors, then messages in the order the queue yields them.
      */
     type FaustTimedEventSeq = FaustTimedEvent & { seq: number };
 
     const kFromAutomation = -2;
     const kFromSensors = -1;
 
-    /** Stands in for the `apply` of a cancelled event. */
+    /** Replaces the `apply` of a cancelled event. */
     const kCancelled = () => {};
 
     /**
-     * Where a control stops looking like a series of edges and starts looking
-     * like a ramp, and how coarsely a ramp is then followed.
-     *
-     * Every Faust slider is an a-rate AudioParam, so one
-     * `linearRampToValueAtTime` gives `process` 128 distinct values for a
-     * single control. Honouring each would mean 128 one-frame `compute` calls
-     * per block, each re-running the DSP's control section, plus 128
-     * `in-param` messages to the main thread.
-     *
-     * Sample accuracy is for edges -- gates, triggers, switches -- which move
-     * once or twice a block. A control that changes more often than
-     * `kRampChanges` is followed every `kRampStride` changes instead, plus the
-     * value it ends the block on.
+     * A control changing more than `kRampChanges` times in a block is treated
+     * as a ramp and followed every `kRampStride` changes, plus the value it
+     * ends the block on. Below that, every change is applied on its frame.
      */
     const kRampChanges = 16;
     const kRampStride = 16;
@@ -201,25 +180,19 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
         protected paramValuesCache: Record<string, number> = {};
 
         /**
-         * Port messages waiting for the block they were timestamped for.
-         *
-         * Sorted by frame, then by arrival. `process` drains everything up to
-         * the end of the block it is about to render; the rest waits.
+         * Port messages waiting for the block they were timestamped for,
+         * sorted by frame and then by arrival.
          */
         protected fEventQueue: FaustTimedEventSeq[] = [];
         protected fEventSeq = 0;
 
         /**
-         * The events of the block about to be rendered.
-         *
-         * Refilled rather than reallocated, so a quiet block allocates
-         * nothing.
+         * The events of the block about to be rendered. Refilled in place.
          */
         protected fBlockEvents: FaustTimedEventSeq[] = [];
 
         /**
          * Scratch space for the frames one control's automation changed on.
-         * Reused for the same reason as `fBlockEvents`.
          */
         protected fChangedFrames: number[] = [];
 
@@ -303,24 +276,21 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
             if (!paramMgrProcessor) return;
             if (paramMgrProcessor.handleEvent) return;
             paramMgrProcessor.handleEvent = (event) => {
-                // A WamEvent's `time` is AudioContext seconds, the same clock
-                // a timestamped port message uses, so it goes through the same
-                // queue. A host that sends none gets what it always got: the
-                // message applied on arrival.
+                // A WamEvent's `time` is AudioContext seconds, so it goes
+                // through the same queue as a timestamped port message.
                 if (event.type === 'wam-midi')
-                    this.atTime(event, () => this.midiMessage(event.data.bytes));
+                    this.atTime(event, () =>
+                        this.midiMessage(event.data.bytes)
+                    );
             };
         }
 
         /**
          * Read a message's timestamp as a whole frame on the audio clock.
-         * Null if it carries none, meaning now.
          *
-         * Both routes round, and both reject anything non-finite. A fraction
-         * would become a fractional slice count and a channel pointer partway
-         * through a sample. A NaN compares false against every frame, so a
-         * queued one would stay at the head of the queue and block every event
-         * behind it.
+         * @returns the frame, rounded, or null if the message carries no
+         * usable timestamp -- meaning apply it now. Non-finite values are
+         * rejected.
          */
         protected messageFrame(msg: FaustMessageTime): number | null {
             const frame = Number.isFinite(msg.frame as number)
@@ -332,16 +302,11 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
         }
 
         /**
-         * Apply `apply` now, or queue it for the frame the sender asked for.
+         * Apply `apply` now, or queue it for the frame `msg` is timestamped
+         * for.
          *
-         * Untimed messages are applied on arrival, between two blocks, which
-         * is equivalent to frame 0 of the next one. A throw from one of those
-         * escapes the port handler and costs that message, as it always did.
-         *
-         * Timed ones have to catch. They run from inside `process`, and the
-         * Web Audio spec's response to a `process` that throws is to fire
-         * `processorerror` and stop calling the node -- so one bad message
-         * would silence the device permanently.
+         * A queued `apply` runs inside `process`, so a throw from one is
+         * caught and logged rather than left to reach the processor.
          */
         protected atTime(msg: FaustMessageTime, apply: () => void) {
             const frame = this.messageFrame(msg);
@@ -363,24 +328,17 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
                     }
                 }
             };
-            // Insert from the back: a sequencer posts in time order, so the
-            // common case is a comparison or two.
+            // Insert from the back: messages usually arrive in time order.
             let i = this.fEventQueue.length;
             while (i > 0 && this.fEventQueue[i - 1].frame > frame) i--;
             this.fEventQueue.splice(i, 0, event);
         }
 
         /**
-         * Cancel everything scheduled and not yet performed.
+         * Cancel every message scheduled and not yet applied: the queue, and
+         * the messages remaining in the block being rendered.
          *
-         * A panic, or the end of the DSP's life, has to reach the notes that
-         * have not sounded yet as well as the ones that have -- otherwise they
-         * play afterwards, over a device that was told to be quiet.
-         *
-         * That means the queue and the rest of the block being rendered, whose
-         * events have already left the queue. Messages only: automation and
-         * sensor writes are the state of the controls through the block, and
-         * an all-notes-off should not stop a filter sweep.
+         * Automation and sensor events are left alone.
          */
         protected flushEvents() {
             this.fEventQueue.length = 0;
@@ -390,29 +348,22 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
         }
 
         /**
-         * Whether a controller number silences the instrument.
-         *
-         * Exactly the two `FaustPolyWebAudioDsp.ctrlChange` treats as
-         * all-notes-off. Not 121, which resets controllers without ending a
-         * note, and not 122, which is a keyboard's local control.
+         * Whether a controller number silences the instrument: 120 all sound
+         * off, 123 all notes off. The two `FaustPolyWebAudioDsp.ctrlChange`
+         * treats as all-notes-off.
          */
         protected isPanic(ctrl: number) {
             return ctrl === 120 || ctrl === 123;
         }
 
         /**
-         * One control's automation for the block, as events.
+         * Append one control's automation for the block to `events`, one
+         * event per change.
          *
-         * A control that holds arrives as a single value, worth an event only
-         * if it differs from what the DSP has. A control that moves arrives as
-         * 128, and each change is an edge due on its own frame.
-         *
-         * Reading only `[0]`, as this used to, pushes every `setValueAtTime`
-         * out to the next block boundary and misses a `1 -> 0 -> 1` inside one
-         * block completely -- a gate that never retriggers.
-         *
-         * Above `kRampChanges` the control is ramping rather than stepping,
-         * and is followed at `kRampStride`. See the constants.
+         * A control that holds through the block arrives as a single value and
+         * yields an event only if it differs from the cached one. A control
+         * that changes more than `kRampChanges` times is followed coarsely;
+         * see the constants.
          */
         protected collectAutomation(
             path: string,
@@ -433,8 +384,8 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
                 const frame = changes[n];
                 events.push(this.paramEvent(path, automation[frame], frame));
             }
-            // Always write the value the block ends on, or the next block
-            // compares against a value the DSP was never given.
+            // Always write the value the block ends on: it is what the next
+            // block compares against.
             const lastChange = changes.length - 1;
             if (lastChange % stride) {
                 const frame = changes[lastChange];
@@ -455,13 +406,11 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
         }
 
         /**
-         * Everything due inside the block starting at `start`.
+         * Everything due inside the block starting at frame `start`:
+         * AudioParam automation, new sensor readings, and the port messages
+         * timestamped for a frame inside it.
          *
-         * Three sources: the automation each `AudioParam` handed over, any new
-         * sensor readings, and the port messages timestamped for a frame
-         * inside the block.
-         *
-         * Sorted by frame, and on a tie by source -- see `FaustTimedEventSeq`.
+         * @returns the events, sorted by frame and then by source
          */
         protected collectEvents(
             parameters: { [key: string]: Float32Array },
@@ -472,10 +421,9 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
             for (const path in parameters) {
                 this.collectAutomation(path, parameters[path], events);
             }
-            // Sensor writes used to run after the parameter read and before
-            // `compute`, so a control that is both an AudioParam and mapped to
-            // an axis took the sensor's value. An event at frame 0 ranked
-            // after the automation preserves that.
+            // At frame 0, ranked after the automation, so a control that is
+            // both an AudioParam and mapped to an axis takes the sensor's
+            // value into the block.
             if (this.fCommunicator.getNewAccDataAvailable()) {
                 const acc = this.fCommunicator.getAcc();
                 if (acc) {
@@ -503,11 +451,9 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
             let ordinal = 0;
             while (this.fEventQueue.length && this.fEventQueue[0].frame < end) {
                 const event = this.fEventQueue.shift() as FaustTimedEventSeq;
-                // A message whose block has passed is late, not lost: it
-                // happens at the top of this one. Several of them collapse
-                // onto frame 0 together, so the tie-break is the order they
-                // come off the queue, which is time order. Posting order would
-                // replay an out-of-order schedule out of order.
+                // A message whose block has passed is applied at the top of
+                // this one. Several collapse onto frame 0, so they are
+                // renumbered in queue order, which is time order.
                 event.frame = Math.max(0, event.frame - start);
                 event.seq = ordinal++;
                 events.push(event);
@@ -611,8 +557,7 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
                     break;
                 }
                 case 'instanceClear': {
-                    // Notes queued before the clear would put back the state
-                    // it just cleared.
+                    // Queued notes would put back the state being cleared.
                     this.flushEvents();
                     this.fDSPCode.instanceClear();
                     break;
@@ -630,8 +575,7 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
                     break;
                 }
                 case 'stop': {
-                    // What was scheduled belongs to the stretch being
-                    // stopped, and should not still be waiting on restart.
+                    // What was scheduled belongs to the stretch being stopped.
                     this.flushEvents();
                     this.fDSPCode.stop();
                     break;
@@ -794,9 +738,8 @@ const getFaustAudioWorkletProcessor = <Poly extends boolean = false>(
             else super.midiMessage(data);
         }
 
-        // The base switch already routes 'keyOn' and 'keyOff' through
-        // `this.keyOn` / `this.keyOff`, overridden below. This exists only to
-        // bind `this` for the port listener.
+        // Binds `this` for the port listener. The base switch routes 'keyOn'
+        // and 'keyOff' through the overrides below.
         protected handleMessageAux = (e: MessageEvent) => {
             super.handleMessageAux(e);
         };

--- a/src/FaustFFTAudioWorkletProcessor.ts
+++ b/src/FaustFFTAudioWorkletProcessor.ts
@@ -69,8 +69,8 @@ const getFaustFFTAudioWorkletProcessor = (
     const { registerProcessor, AudioWorkletProcessor, sampleRate } =
         globalThis as unknown as AudioWorkletGlobalScope;
 
-    // `currentFrame` advances by a block between calls to `process`, so unlike
-    // `sampleRate` it has to be read at call time.
+    // `currentFrame` advances every `process` call, so it must be read then,
+    // not destructured once.
     const audioClock = globalThis as unknown as AudioWorkletGlobalScope;
 
     /** The render quantum, fixed by the Web Audio API. */
@@ -190,23 +190,23 @@ const getFaustFFTAudioWorkletProcessor = (
         /**
          * Port messages waiting for the block they were timestamped for.
          *
-         * The node takes a `time` on every control it sends. This processor
-         * used to ignore it and apply the message the moment it arrived, which
-         * for a MIDI message -- nothing mirrors those onto an `AudioParam` --
-         * meant the timestamp did nothing at all and the message landed
-         * whenever the main thread got round to posting it.
+         * The node puts a `time` on every control it sends. This processor
+         * used to ignore it, which mattered most for MIDI messages: nothing
+         * mirrors those onto an `AudioParam`, so the timestamp did nothing and
+         * the message landed whenever it was posted.
          *
-         * They wait here instead, and are applied at the top of the block that
-         * contains the instant. Two limits worth naming. It is a block, not a
-         * sample: this processor buffers its input into an FFT window and
-         * hands the DSP whole frames of spectrum, so there is no such thing as
-         * a control write partway through what it computes. And a `param`
-         * message still resolves a block later than that, because the
-         * per-block `[0]`-against-cache comparison below reads the AudioParam
-         * at the *start* of the block and writes the pre-`time` value straight
-         * back over it; the value the caller asked for arrives with the next
-         * block. Nothing is computed in between, so there is no artefact --
-         * just one block, and only for parameters.
+         * They now wait here and are applied at the top of the block that
+         * contains the instant. Two limits:
+         *
+         * Block, not sample. This processor buffers input into an FFT window
+         * and hands the DSP whole frames of spectrum, so a control write
+         * partway through what it computes has no meaning.
+         *
+         * A `param` still resolves one block later than that. The
+         * `[0]`-against-cache sync below reads the AudioParam at the start of
+         * the block and writes the pre-`time` value back over it; the intended
+         * value arrives with the next block. Nothing is computed in between,
+         * so there is no artefact.
          */
         protected fEventQueue: {
             frame: number;
@@ -519,8 +519,8 @@ const getFaustFFTAudioWorkletProcessor = (
 
             if (!this.fDSPCode) return true;
 
-            // Anything timed for this block, before the block's own values are
-            // read -- see `fEventQueue` for what that does and does not buy.
+            // Anything timed for this block, before its own values are read.
+            // See `fEventQueue` for what this does and does not buy.
             this.applyDueEvents(audioClock.currentFrame);
 
             for (const path in parameters) {
@@ -608,10 +608,10 @@ const getFaustFFTAudioWorkletProcessor = (
 
         /**
          * Read a message's timestamp as a whole frame on the audio clock.
+         * Null if it carries none, meaning now.
          *
-         * Null when it carries none, which means now. A fractional, NaN or
-         * infinite one would sit in the queue comparing false against
-         * everything, so it is rounded here or refused.
+         * Rounded, and non-finite values rejected: a NaN compares false
+         * against every frame and would block the queue behind it.
          */
         protected messageFrame(msg: {
             time?: number;
@@ -626,12 +626,11 @@ const getFaustFFTAudioWorkletProcessor = (
         }
 
         /**
-         * Perform `apply` now, or at the top of the block that contains the
-         * frame the sender asked for.
+         * Apply `apply` now, or at the top of the block containing the frame
+         * the sender asked for.
          *
-         * A throw from a queued one is caught: it would otherwise come out of
-         * `process`, and the spec's answer to that is to stop calling the node
-         * for the rest of its life.
+         * Queued ones catch: a throw would otherwise escape `process`, and the
+         * spec's response is to stop calling the node permanently.
          */
         protected atTime(
             msg: { time?: number; frame?: number },
@@ -661,7 +660,7 @@ const getFaustFFTAudioWorkletProcessor = (
         protected applyDueEvents(start: number) {
             const end = start + kBlockSize;
             while (this.fEventQueue.length && this.fEventQueue[0].frame < end) {
-                // A message whose block has gone by is late, not lost.
+                // A message whose block has passed is late, not lost.
                 this.fEventQueue.shift()!.apply();
             }
         }

--- a/src/FaustFFTAudioWorkletProcessor.ts
+++ b/src/FaustFFTAudioWorkletProcessor.ts
@@ -190,18 +190,23 @@ const getFaustFFTAudioWorkletProcessor = (
         /**
          * Port messages waiting for the block they were timestamped for.
          *
-         * The node takes a `time` on every control it sends, and it schedules
-         * the matching `AudioParam` for that instant. Applying the message the
-         * moment it arrives would write the value early, and the per-block
-         * comparison below would then take it back off again at the next
-         * block, and put it back at the right one -- a value that flickers
-         * rather than one that lands.
+         * The node takes a `time` on every control it sends. This processor
+         * used to ignore it and apply the message the moment it arrived, which
+         * for a MIDI message -- nothing mirrors those onto an `AudioParam` --
+         * meant the timestamp did nothing at all and the message landed
+         * whenever the main thread got round to posting it.
          *
-         * So they wait here, and are applied at the top of the block that
-         * contains them. Block granularity, not the sample accuracy the
-         * ordinary processor manages: this one buffers its input into an FFT
-         * window and hands the DSP whole frames of spectrum, so there is no
-         * such thing as a control write partway through what it computes.
+         * They wait here instead, and are applied at the top of the block that
+         * contains the instant. Two limits worth naming. It is a block, not a
+         * sample: this processor buffers its input into an FFT window and
+         * hands the DSP whole frames of spectrum, so there is no such thing as
+         * a control write partway through what it computes. And a `param`
+         * message still resolves a block later than that, because the
+         * per-block `[0]`-against-cache comparison below reads the AudioParam
+         * at the *start* of the block and writes the pre-`time` value straight
+         * back over it; the value the caller asked for arrives with the next
+         * block. Nothing is computed in between, so there is no artefact --
+         * just one block, and only for parameters.
          */
         protected fEventQueue: {
             frame: number;
@@ -515,8 +520,7 @@ const getFaustFFTAudioWorkletProcessor = (
             if (!this.fDSPCode) return true;
 
             // Anything timed for this block, before the block's own values are
-            // read: a message and the AudioParam it was mirrored onto then
-            // agree, rather than taking turns.
+            // read -- see `fEventQueue` for what that does and does not buy.
             this.applyDueEvents(audioClock.currentFrame);
 
             for (const path in parameters) {

--- a/src/FaustFFTAudioWorkletProcessor.ts
+++ b/src/FaustFFTAudioWorkletProcessor.ts
@@ -355,8 +355,12 @@ const getFaustFFTAudioWorkletProcessor = (
             if (!paramMgrProcessor) return;
             if (paramMgrProcessor.handleEvent) return;
             paramMgrProcessor.handleEvent = (event) => {
+                // A WamEvent's `time` is AudioContext seconds, so it goes
+                // through the same queue as a timestamped port message --
+                // block granularity here, as for everything else this
+                // processor is handed. See `fEventQueue`.
                 if (event.type === 'wam-midi')
-                    this.midiMessage(event.data.bytes);
+                    this.atTime(event, () => this.midiMessage(event.data.bytes));
             };
         }
 

--- a/src/FaustFFTAudioWorkletProcessor.ts
+++ b/src/FaustFFTAudioWorkletProcessor.ts
@@ -69,8 +69,7 @@ const getFaustFFTAudioWorkletProcessor = (
     const { registerProcessor, AudioWorkletProcessor, sampleRate } =
         globalThis as unknown as AudioWorkletGlobalScope;
 
-    // `currentFrame` advances every `process` call, so it must be read then,
-    // not destructured once.
+    // Read at call time: `currentFrame` advances every `process` call.
     const audioClock = globalThis as unknown as AudioWorkletGlobalScope;
 
     /** The render quantum, fixed by the Web Audio API. */
@@ -190,23 +189,13 @@ const getFaustFFTAudioWorkletProcessor = (
         /**
          * Port messages waiting for the block they were timestamped for.
          *
-         * The node puts a `time` on every control it sends. This processor
-         * used to ignore it, which mattered most for MIDI messages: nothing
-         * mirrors those onto an `AudioParam`, so the timestamp did nothing and
-         * the message landed whenever it was posted.
+         * Applied at the top of that block, not on its exact sample: this
+         * processor hands its DSP whole frames of spectrum, so a control write
+         * partway through one has no meaning.
          *
-         * They now wait here and are applied at the top of the block that
-         * contains the instant. Two limits:
-         *
-         * Block, not sample. This processor buffers input into an FFT window
-         * and hands the DSP whole frames of spectrum, so a control write
-         * partway through what it computes has no meaning.
-         *
-         * A `param` still resolves one block later than that. The
+         * A `param` message resolves one block later again, because the
          * `[0]`-against-cache sync below reads the AudioParam at the start of
-         * the block and writes the pre-`time` value back over it; the intended
-         * value arrives with the next block. Nothing is computed in between,
-         * so there is no artefact.
+         * the block and writes the pre-`time` value back over it.
          */
         protected fEventQueue: {
             frame: number;
@@ -356,11 +345,11 @@ const getFaustFFTAudioWorkletProcessor = (
             if (paramMgrProcessor.handleEvent) return;
             paramMgrProcessor.handleEvent = (event) => {
                 // A WamEvent's `time` is AudioContext seconds, so it goes
-                // through the same queue as a timestamped port message --
-                // block granularity here, as for everything else this
-                // processor is handed. See `fEventQueue`.
+                // through the same queue as a timestamped port message.
                 if (event.type === 'wam-midi')
-                    this.atTime(event, () => this.midiMessage(event.data.bytes));
+                    this.atTime(event, () =>
+                        this.midiMessage(event.data.bytes)
+                    );
             };
         }
 
@@ -524,7 +513,6 @@ const getFaustFFTAudioWorkletProcessor = (
             if (!this.fDSPCode) return true;
 
             // Anything timed for this block, before its own values are read.
-            // See `fEventQueue` for what this does and does not buy.
             this.applyDueEvents(audioClock.currentFrame);
 
             for (const path in parameters) {
@@ -612,10 +600,10 @@ const getFaustFFTAudioWorkletProcessor = (
 
         /**
          * Read a message's timestamp as a whole frame on the audio clock.
-         * Null if it carries none, meaning now.
          *
-         * Rounded, and non-finite values rejected: a NaN compares false
-         * against every frame and would block the queue behind it.
+         * @returns the frame, rounded, or null if the message carries no
+         * usable timestamp -- meaning apply it now. Non-finite values are
+         * rejected.
          */
         protected messageFrame(msg: {
             time?: number;
@@ -631,10 +619,10 @@ const getFaustFFTAudioWorkletProcessor = (
 
         /**
          * Apply `apply` now, or at the top of the block containing the frame
-         * the sender asked for.
+         * `msg` is timestamped for.
          *
-         * Queued ones catch: a throw would otherwise escape `process`, and the
-         * spec's response is to stop calling the node permanently.
+         * A queued `apply` runs inside `process`, so a throw from one is
+         * caught and logged rather than left to reach the processor.
          */
         protected atTime(
             msg: { time?: number; frame?: number },
@@ -664,7 +652,7 @@ const getFaustFFTAudioWorkletProcessor = (
         protected applyDueEvents(start: number) {
             const end = start + kBlockSize;
             while (this.fEventQueue.length && this.fEventQueue[0].frame < end) {
-                // A message whose block has passed is late, not lost.
+                // A message whose block has passed is applied here.
                 this.fEventQueue.shift()!.apply();
             }
         }

--- a/src/FaustFFTAudioWorkletProcessor.ts
+++ b/src/FaustFFTAudioWorkletProcessor.ts
@@ -69,6 +69,13 @@ const getFaustFFTAudioWorkletProcessor = (
     const { registerProcessor, AudioWorkletProcessor, sampleRate } =
         globalThis as unknown as AudioWorkletGlobalScope;
 
+    // `currentFrame` advances by a block between calls to `process`, so unlike
+    // `sampleRate` it has to be read at call time.
+    const audioClock = globalThis as unknown as AudioWorkletGlobalScope;
+
+    /** The render quantum, fixed by the Web Audio API. */
+    const kBlockSize = 128;
+
     const {
         FaustBaseWebAudioDsp,
         FaustWasmInstantiator,
@@ -179,6 +186,27 @@ const getFaustFFTAudioWorkletProcessor = (
         protected fDSPCode: FaustMonoWebAudioDsp;
 
         protected paramValuesCache: Record<string, number> = {};
+
+        /**
+         * Port messages waiting for the block they were timestamped for.
+         *
+         * The node takes a `time` on every control it sends, and it schedules
+         * the matching `AudioParam` for that instant. Applying the message the
+         * moment it arrives would write the value early, and the per-block
+         * comparison below would then take it back off again at the next
+         * block, and put it back at the right one -- a value that flickers
+         * rather than one that lands.
+         *
+         * So they wait here, and are applied at the top of the block that
+         * contains them. Block granularity, not the sample accuracy the
+         * ordinary processor manages: this one buffers its input into an FFT
+         * window and hands the DSP whole frames of spectrum, so there is no
+         * such thing as a control write partway through what it computes.
+         */
+        protected fEventQueue: {
+            frame: number;
+            apply: () => void;
+        }[] = [];
 
         protected wamInfo?: { moduleId: string; instanceId: string };
         protected communicator: FaustAudioWorkletProcessorCommunicator;
@@ -486,6 +514,11 @@ const getFaustFFTAudioWorkletProcessor = (
 
             if (!this.fDSPCode) return true;
 
+            // Anything timed for this block, before the block's own values are
+            // read: a message and the AudioParam it was mirrored onto then
+            // agree, rather than taking turns.
+            this.applyDueEvents(audioClock.currentFrame);
+
             for (const path in parameters) {
                 if (fftParamKeywords.find((k) => `/${path}`.endsWith(k)))
                     continue;
@@ -569,6 +602,66 @@ const getFaustFFTAudioWorkletProcessor = (
             return true;
         }
 
+        /**
+         * Read a message's timestamp as a whole frame on the audio clock.
+         *
+         * Null when it carries none, which means now. A fractional, NaN or
+         * infinite one would sit in the queue comparing false against
+         * everything, so it is rounded here or refused.
+         */
+        protected messageFrame(msg: {
+            time?: number;
+            frame?: number;
+        }): number | null {
+            const frame = Number.isFinite(msg.frame as number)
+                ? (msg.frame as number)
+                : Number.isFinite(msg.time as number)
+                  ? (msg.time as number) * sampleRate
+                  : null;
+            return frame === null ? null : Math.round(frame);
+        }
+
+        /**
+         * Perform `apply` now, or at the top of the block that contains the
+         * frame the sender asked for.
+         *
+         * A throw from a queued one is caught: it would otherwise come out of
+         * `process`, and the spec's answer to that is to stop calling the node
+         * for the rest of its life.
+         */
+        protected atTime(
+            msg: { time?: number; frame?: number },
+            apply: () => void
+        ) {
+            const frame = this.messageFrame(msg);
+            if (frame === null) {
+                apply();
+                return;
+            }
+            const guarded = () => {
+                try {
+                    apply();
+                } catch (error) {
+                    console.error(
+                        `Faust: a message timed for frame ${frame} threw and was dropped`,
+                        error
+                    );
+                }
+            };
+            let i = this.fEventQueue.length;
+            while (i > 0 && this.fEventQueue[i - 1].frame > frame) i--;
+            this.fEventQueue.splice(i, 0, { frame, apply: guarded });
+        }
+
+        /** Apply everything due by the end of the block starting at `start`. */
+        protected applyDueEvents(start: number) {
+            const end = start + kBlockSize;
+            while (this.fEventQueue.length && this.fEventQueue[0].frame < end) {
+                // A message whose block has gone by is late, not lost.
+                this.fEventQueue.shift()!.apply();
+            }
+        }
+
         protected handleMessageAux = (e: MessageEvent) => {
             // use arrow function for binding
             const msg = e.data;
@@ -576,18 +669,24 @@ const getFaustFFTAudioWorkletProcessor = (
             switch (msg.type) {
                 // Generic MIDI message
                 case 'midi':
-                    this.midiMessage(msg.data);
+                    this.atTime(msg, () => this.midiMessage(msg.data));
                     break;
                 // Typed MIDI message
                 case 'ctrlChange':
-                    this.ctrlChange(msg.data[0], msg.data[1], msg.data[2]);
+                    this.atTime(msg, () =>
+                        this.ctrlChange(msg.data[0], msg.data[1], msg.data[2])
+                    );
                     break;
                 case 'pitchWheel':
-                    this.pitchWheel(msg.data[0], msg.data[1]);
+                    this.atTime(msg, () =>
+                        this.pitchWheel(msg.data[0], msg.data[1])
+                    );
                     break;
                 // Generic data message
                 case 'param':
-                    this.setParamValue(msg.data.path, msg.data.value);
+                    this.atTime(msg, () =>
+                        this.setParamValue(msg.data.path, msg.data.value)
+                    );
                     break;
                 // Plot handler set on demand
                 case 'setPlotHandler': {
@@ -610,10 +709,12 @@ const getFaustFFTAudioWorkletProcessor = (
                     break;
                 }
                 case 'stop': {
+                    this.fEventQueue.length = 0;
                     this.fDSPCode?.stop();
                     break;
                 }
                 case 'destroy': {
+                    this.fEventQueue.length = 0;
                     this.port.close();
                     this.destroy();
                     break;

--- a/src/FaustWebAudioDsp.ts
+++ b/src/FaustWebAudioDsp.ts
@@ -30,21 +30,18 @@ export type PlotHandler = (
 export type MetadataHandler = (key: string, value: string) => void;
 
 /**
- * A control write due at a known frame inside the block about to be rendered.
+ * A control write due at a known frame inside the next block.
  *
- * `compute` renders the block in slices when it is given events: up to the
- * frame of the next one, apply it, carry on. That is what
- * `architecture/faust/dsp/timed-dsp.h` does for a native host, and it is the
- * only way a web host can place a note on a sample rather than on the
- * 128-frame boundary that follows it.
+ * Given a list of these, `compute` renders the block in slices: up to the
+ * frame of the next event, apply it, carry on. The same approach as
+ * `architecture/faust/dsp/timed-dsp.h`, which is how a native host gets
+ * sample-accurate MIDI.
  *
- * `apply` is a closure rather than a `{ path, value }` pair so that the same
- * queue can carry a parameter write, a `keyOn` and a MIDI message -- the
- * caller already knows how to perform each of them, and the DSP only has to
- * know when.
+ * `apply` is a closure rather than a `{ path, value }` pair so one list can
+ * carry parameter writes, `keyOn`s and MIDI messages together. The caller
+ * knows how to perform each; the DSP only needs to know when.
  *
- * The array must be sorted by frame, and every frame must fall inside the
- * block.
+ * The list must be sorted by frame. Frames outside the block are clamped.
  */
 export interface FaustTimedEvent {
     /** Frame offset from the start of the block, 0 <= frame < bufferSize */
@@ -753,19 +750,19 @@ export interface IFaustBaseWebAudioDsp {
 export type IFaustMonoWebAudioDsp = IFaustBaseWebAudioDsp;
 
 /**
- * A node's controls, each with the instant it takes effect.
+ * A node's controls, each taking an optional time.
  *
- * `time` is AudioContext seconds -- the clock `AudioParam.setValueAtTime`
- * takes -- so a note and a parameter ramp can be scheduled against one
- * another. It is declared here, on the node, rather than on
- * `IFaustBaseWebAudioDsp`, because it is a node's to offer: a node reaches
- * its DSP across a message port and can hold a control write until the block
- * that contains the instant, where a DSP is already inside the block by the
- * time anyone asks it for anything.
+ * `time` is in AudioContext seconds, the same clock as
+ * `AudioParam.setValueAtTime`, so notes and parameter automation can be
+ * scheduled against each other.
  *
- * An AudioWorklet node lands the control on the sample it named. A
- * ScriptProcessor node (`sp: true`) has no such queue and applies it on
- * arrival, as it always did: the argument is accepted and ignored there.
+ * It is declared on the node rather than on `IFaustBaseWebAudioDsp` because
+ * only a node can honour it: it reaches its DSP over a message port and can
+ * hold the write until the right block. A DSP is called from inside the block
+ * and has nowhere to put a future event.
+ *
+ * An AudioWorklet node applies the control on the exact sample. A
+ * ScriptProcessor node (`sp: true`) accepts `time` and ignores it.
  */
 export interface IFaustMonoWebAudioNode
     extends IFaustMonoWebAudioDsp, AudioNode {
@@ -857,14 +854,14 @@ export class FaustBaseWebAudioDsp implements IFaustBaseWebAudioDsp {
     protected fAudioOutputs!: number;
 
     /**
-     * Block-start address of every wasm audio channel, and the heap view that
-     * holds the tables pointing at them.
+     * Block-start address of every wasm audio channel, plus the heap view
+     * holding the pointer tables.
      *
-     * A block rendered in slices has to hand wasm a channel pointer that
-     * starts at the first frame of the slice, so `setBufferOffset` rewrites
-     * the tables between slices and needs the unmoved address to offset from.
-     * Only the tables move: the `fInChannels` / `fOutChannels` views built in
-     * `initMemory` describe the whole block and stay valid throughout.
+     * Rendering a slice means giving wasm a channel pointer to the slice's
+     * first frame, so `setBufferOffset` rewrites the tables and needs these
+     * unmoved addresses to offset from. Only the tables move; the
+     * `fInChannels` / `fOutChannels` views from `initMemory` still span the
+     * whole block and stay valid.
      */
     protected fInBase: number[] = [];
     protected fOutBase: number[] = [];
@@ -1093,14 +1090,14 @@ export class FaustBaseWebAudioDsp implements IFaustBaseWebAudioDsp {
     }
 
     /**
-     * Render a whole block through `render`, pausing on each event.
+     * Render a whole block through `render`, stopping at each event.
      *
-     * This is the JS shape of what `timed-dsp.h` does natively: walk to the
-     * frame of the next control write, render what came before it, apply it,
-     * carry on. Doing it here rather than in each `compute` keeps the two DSPs
-     * responsible only for the thing they actually differ on -- what rendering
-     * a slice means. With no events the block is a single slice, which is the
-     * path every existing caller takes.
+     * Render up to the next event's frame, apply it, continue. Living in the
+     * base class means mono and poly only have to supply what rendering a
+     * slice means.
+     *
+     * With no events the block is one slice, which is what every caller that
+     * passes no events gets.
      */
     protected renderBlock(
         events: FaustTimedEvent[] | undefined,
@@ -1113,12 +1110,11 @@ export class FaustBaseWebAudioDsp implements IFaustBaseWebAudioDsp {
         let frame = 0;
         for (let i = 0; i < events.length; i++) {
             const event = events[i];
-            // Clamped rather than trusted. A frame past the end of the block
-            // would hand wasm a count that runs off the end of the channel,
-            // and this is the audio thread: the cost is two comparisons.
+            // Clamped, not trusted: a frame past the end of the block would
+            // give wasm a count that runs off the end of the channel.
             const at = Math.min(Math.max(event.frame, 0), this.fBufferSize);
-            // Two events on the same frame leave an empty slice between them,
-            // and wasm has nothing to do with a count of zero.
+            // Two events on one frame leave an empty slice between them,
+            // which is not worth a wasm call.
             if (at > frame) {
                 render(frame, at - frame);
                 frame = at;
@@ -1131,14 +1127,15 @@ export class FaustBaseWebAudioDsp implements IFaustBaseWebAudioDsp {
     }
 
     /**
-     * Perform every event without rendering anything.
+     * Apply every event without rendering.
      *
-     * A block the DSP declines to render still has to take its control
-     * writes. They were taken off the queue to be applied here, so a `keyOn`
-     * dropped because the node was stopped, or because an input was not
-     * connected yet, is a note that never sounds and never will -- and the
-     * DSP's cached parameter values would go on disagreeing with the host's.
-     * Only a destroyed DSP drops them, which is the point of destroying it.
+     * For the blocks `compute` returns early from: stopped, or an input or
+     * output not connected yet. The events have already left the processor's
+     * queue, so dropping them here loses them permanently -- a `keyOn` that
+     * never sounds, or a parameter the DSP and the host disagree about from
+     * then on.
+     *
+     * A destroyed DSP is the exception, and does drop them.
      */
     protected applyEvents(events?: FaustTimedEvent[]) {
         if (!events) return;
@@ -1148,8 +1145,8 @@ export class FaustBaseWebAudioDsp implements IFaustBaseWebAudioDsp {
     /**
      * Point the wasm channel tables at frame `offset` of the block.
      *
-     * Called by each slice rather than left set afterwards, so nothing outside
-     * a `compute` has to care where the last one left them.
+     * Each slice sets this before rendering, so nothing outside `compute`
+     * depends on where the previous slice left the tables.
      */
     protected setBufferOffset(offset: number) {
         const bytes = offset * this.fSampleSize;
@@ -1790,10 +1787,10 @@ export class FaustMonoWebAudioDsp
     private fSampleRate: number;
 
     /**
-     * One slice of a block, for `renderBlock`.
+     * Render one slice, for `renderBlock`.
      *
-     * Built once rather than per call: `compute` runs on the audio thread and
-     * has no business allocating a closure every 128 frames.
+     * A field rather than an inline closure so it is allocated once instead of
+     * on every `compute` call.
      */
     private fRenderSlice = (offset: number, count: number) => {
         this.setBufferOffset(offset);
@@ -1931,9 +1928,8 @@ export class FaustMonoWebAudioDsp
             }
         }
 
-        // Remember where each channel starts. `setBufferOffset` moves the
-        // tables between slices, so after the first slice the tables no longer
-        // say where the block began.
+        // Record where each channel starts: `setBufferOffset` overwrites the
+        // tables between slices, so they stop being a record of that.
         this.fHEAP32 = HEAP32;
         this.fInBase = [];
         for (let chan = 0; chan < this.getNumInputs(); chan++) {
@@ -2021,7 +2017,7 @@ export class FaustMonoWebAudioDsp
         // Possibly call an externally given callback (for instance to synchronize playing a MIDIFile...)
         if (this.fComputeHandler) this.fComputeHandler(this.fBufferSize);
 
-        // Compute, in slices around the timed events if there are any
+        // Compute -- in slices around the events, if there are any
         this.renderBlock(events, this.fRenderSlice);
 
         // Update bargraph
@@ -2248,9 +2244,8 @@ export class FaustWebAudioDspVoice {
         $outputZero: number,
         $outputsHalf: number
     ) {
-        // `>> 1` rather than `/ 2`: a block rendered in slices hands this
-        // whatever the slice is long, odd counts included, and wasm counts
-        // whole frames. The second half takes the remainder so the two add up.
+        // `>> 1` rather than `/ 2` because `bufferSize` need not be even, and
+        // wasm counts whole frames. The second half takes the remainder.
         const size = bufferSize >> 1;
 
         // Reset envelops
@@ -2293,30 +2288,24 @@ export class FaustPolyWebAudioDsp
     private fVoiceTable: FaustWebAudioDspVoice[];
     private fSampleRate: number;
 
-    /**
-     * The voices whose crossfade this block already rendered whole.
-     *
-     * Reused rather than rebuilt: `compute` runs on the audio thread, and a
-     * steal is rare enough that this is almost always empty.
-     */
+    /** Voices whose crossfade this block already rendered in full. */
     private fStolen: FaustWebAudioDspVoice[] = [];
 
     /**
-     * One slice of a block: render every live voice into the sum, then run
-     * the effect over it.
+     * Render one slice: every live voice into the sum, then the effect.
      *
-     * Built once rather than per call, since `compute` runs on the audio
-     * thread. Everything it touches -- the mixer, the voice table, the effect
-     * -- takes a frame count already, so a slice is the same work over fewer
-     * frames rather than a different code path.
+     * The mixer, the voices and the effect all take a frame count, so a slice
+     * is the same work over fewer frames. A field rather than an inline
+     * closure so it is allocated once instead of on every `compute` call.
      *
-     * The sum is cleared once for the block rather than once per slice, and
-     * the voices whose note was stolen were rendered across the whole block
-     * before the first slice, so this leaves them alone. A voice that becomes
-     * `kLegatoVoice` partway through the block is not one of them: it keeps
-     * playing the note it is losing for the rest of the block and takes its
-     * crossfade at the top of the next one, exactly as it did when a `keyOn`
-     * could only ever arrive between two blocks.
+     * Two things `compute` does around this. The sum is cleared once for the
+     * block, not per slice, because `renderStolenVoices` has already written
+     * across the whole of it. And those stolen voices are skipped here.
+     *
+     * A voice that becomes `kLegatoVoice` partway through the block is not one
+     * of them: it plays out the note it is losing and crossfades at the top of
+     * the next block, as it did when a `keyOn` could only arrive between
+     * blocks.
      */
     private fRenderSlice = (offset: number, count: number) => {
         this.setBufferOffset(offset);
@@ -2334,12 +2323,10 @@ export class FaustPolyWebAudioDsp
                 this.fAudioMixing,
                 this.fAudioOutputs
             );
-            // The loudest the voice got anywhere in the block. Whether a
-            // release has died away is a question about the block: a slice of
-            // a few frames landing on a zero crossing reads nothing from a
-            // voice that is still plainly sounding, and freeing it there cuts
-            // the tail off. The check itself waits until `compute` has the
-            // whole block, below.
+            // Keep the loudest level from any slice. A few frames landing on
+            // a zero crossing read near silence from a voice that is still
+            // sounding, so `compute` decides whether a release has finished
+            // once the whole block is done.
             if (level > voice.fLevel) voice.fLevel = level;
         });
         if (this.fInstance.effectAPI)
@@ -2352,15 +2339,14 @@ export class FaustPolyWebAudioDsp
     };
 
     /**
-     * Render the voices whose note was stolen, across the whole block.
+     * Render the stolen voices, each across the whole block.
      *
-     * A steal is a crossfade: the voice renders the note it is losing over the
-     * first half of the buffer, that half is faded out, and the note it is
-     * taking renders the second half. Half of a *block* -- 64 frames -- and
-     * not half of whatever slice the voice happens to fall in, which late in a
-     * sliced block is a fade of one or two frames, or of none at all, which is
-     * a click. So this runs before the slicing, over the full block, and the
-     * slices skip these voices.
+     * A steal is a crossfade: the voice plays the note it is losing over the
+     * first half of the buffer, that half fades out, and the new note plays
+     * the second half. The fade has to be half a block -- 64 frames -- rather
+     * than half a slice, which late in the block would be a frame or two, or
+     * nothing at all. So this runs before the slicing, and `fRenderSlice`
+     * skips these voices.
      */
     private renderStolenVoices() {
         const stolen = this.fStolen;
@@ -2394,10 +2380,10 @@ export class FaustPolyWebAudioDsp
     /**
      * Move the mixing tables along with the input and output ones.
      *
-     * `fAudioMixing` is where a voice renders before it is summed into the
-     * output, so it has to follow the slice. `fAudioMixingHalf` is the legato
-     * split point: inside the slice rather than at a fixed half of the block,
-     * on the same `count >> 1` that `computeLegato` uses.
+     * `fAudioMixing` is where a voice renders before being summed into the
+     * output, so it follows the slice. `fAudioMixingHalf` is the crossfade
+     * split point, `count >> 1` frames in, matching `computeLegato`. Only
+     * `renderStolenVoices` uses it, and always with the whole block.
      */
     private setMixingOffset(offset: number, count: number) {
         const bytes = offset * this.fSampleSize;
@@ -2591,9 +2577,8 @@ export class FaustPolyWebAudioDsp
             }
         }
 
-        // Remember where each channel starts. `setBufferOffset` moves the
-        // tables between slices, so after the first slice the tables no longer
-        // say where the block began.
+        // Record where each channel starts: `setBufferOffset` overwrites the
+        // tables between slices, so they stop being a record of that.
         this.fHEAP32 = HEAP32;
         this.fInBase = [];
         for (let chan = 0; chan < this.getNumInputs(); chan++) {
@@ -2761,9 +2746,9 @@ export class FaustPolyWebAudioDsp
         // Possibly call an externally given callback (for instance to synchronize playing a MIDIFile...)
         if (this.fComputeHandler) this.fComputeHandler(this.fBufferSize);
 
-        // Clear the sum once for the block, not once per slice: a stolen
-        // voice writes its whole crossfade into it before the slices start,
-        // and a slice clearing its own range would wipe part of that.
+        // Clear the sum once for the block, not per slice: the stolen voices
+        // below write across the whole of it, and a slice clearing its own
+        // range afterwards would erase part of that.
         this.setBufferOffset(0);
         this.setMixingOffset(0, this.fBufferSize);
         this.fInstance.mixerAPI.clearOutput(
@@ -2774,11 +2759,11 @@ export class FaustPolyWebAudioDsp
         this.fVoiceTable.forEach((voice) => (voice.fLevel = 0));
         this.renderStolenVoices();
 
-        // Compute, in slices around the timed events if there are any
+        // Compute -- in slices around the events, if there are any
         this.renderBlock(events, this.fRenderSlice);
 
-        // A voice in release whose level never rose above the threshold
-        // anywhere in the block has died away, and its slot goes back.
+        // A releasing voice that stayed below the threshold for every slice
+        // has died away, and its slot is free again.
         this.fVoiceTable.forEach((voice) => {
             if (
                 voice.fCurNote === FaustWebAudioDspVoice.kReleaseVoice &&

--- a/src/FaustWebAudioDsp.ts
+++ b/src/FaustWebAudioDsp.ts
@@ -29,6 +29,30 @@ export type PlotHandler = (
 ) => void;
 export type MetadataHandler = (key: string, value: string) => void;
 
+/**
+ * A control write due at a known frame inside the block about to be rendered.
+ *
+ * `compute` renders the block in slices when it is given events: up to the
+ * frame of the next one, apply it, carry on. That is what
+ * `architecture/faust/dsp/timed-dsp.h` does for a native host, and it is the
+ * only way a web host can place a note on a sample rather than on the
+ * 128-frame boundary that follows it.
+ *
+ * `apply` is a closure rather than a `{ path, value }` pair so that the same
+ * queue can carry a parameter write, a `keyOn` and a MIDI message -- the
+ * caller already knows how to perform each of them, and the DSP only has to
+ * know when.
+ *
+ * The array must be sorted by frame, and every frame must fall inside the
+ * block.
+ */
+export interface FaustTimedEvent {
+    /** Frame offset from the start of the block, 0 <= frame < bufferSize */
+    frame: number;
+    /** Performed just before the slice starting at `frame` is rendered */
+    apply: () => void;
+}
+
 // Implementation API
 export type UIHandler = (item: FaustUIItem) => void;
 
@@ -540,8 +564,15 @@ export interface IFaustBaseWebAudioDsp {
      *
      * @param inputs - the input audio buffers
      * @param outputs - the output audio buffers
+     * @param events - control writes due inside this block, sorted by frame.
+     * The block is rendered in slices around them, so each one takes effect on
+     * the frame it was timestamped for instead of at the start of the block.
      */
-    compute(inputs: Float32Array[], outputs: Float32Array[]): boolean;
+    compute(
+        inputs: Float32Array[],
+        outputs: Float32Array[],
+        events?: FaustTimedEvent[]
+    ): boolean;
 
     /**
      * Give a handler to be called on 'declare key value' kind of metadata.
@@ -786,6 +817,20 @@ export class FaustBaseWebAudioDsp implements IFaustBaseWebAudioDsp {
     protected fAudioInputs!: number;
     protected fAudioOutputs!: number;
 
+    /**
+     * Block-start address of every wasm audio channel, and the heap view that
+     * holds the tables pointing at them.
+     *
+     * A block rendered in slices has to hand wasm a channel pointer that
+     * starts at the first frame of the slice, so `setBufferOffset` rewrites
+     * the tables between slices and needs the unmoved address to offset from.
+     * Only the tables move: the `fInChannels` / `fOutChannels` views built in
+     * `initMemory` describe the whole block and stay valid throughout.
+     */
+    protected fInBase: number[] = [];
+    protected fOutBase: number[] = [];
+    protected fHEAP32!: Int32Array;
+
     protected fBufferSize: number;
     protected fPtrSize: number;
     protected fSampleSize: number;
@@ -1006,6 +1051,62 @@ export class FaustBaseWebAudioDsp implements IFaustBaseWebAudioDsp {
         this.fSoundfileBuffers = soundfiles;
         this.fAcc = { x: [], y: [], z: [] };
         this.fGyr = { x: [], y: [], z: [] };
+    }
+
+    /**
+     * Render a whole block through `render`, pausing on each event.
+     *
+     * This is the JS shape of what `timed-dsp.h` does natively: walk to the
+     * frame of the next control write, render what came before it, apply it,
+     * carry on. Doing it here rather than in each `compute` keeps the two DSPs
+     * responsible only for the thing they actually differ on -- what rendering
+     * a slice means. With no events the block is a single slice, which is the
+     * path every existing caller takes.
+     */
+    protected renderBlock(
+        events: FaustTimedEvent[] | undefined,
+        render: (offset: number, count: number) => void
+    ) {
+        if (!events || events.length === 0) {
+            render(0, this.fBufferSize);
+            return;
+        }
+        let frame = 0;
+        for (let i = 0; i < events.length; i++) {
+            const event = events[i];
+            // Clamped rather than trusted. A frame past the end of the block
+            // would hand wasm a count that runs off the end of the channel,
+            // and this is the audio thread: the cost is two comparisons.
+            const at = Math.min(Math.max(event.frame, 0), this.fBufferSize);
+            // Two events on the same frame leave an empty slice between them,
+            // and wasm has nothing to do with a count of zero.
+            if (at > frame) {
+                render(frame, at - frame);
+                frame = at;
+            }
+            event.apply();
+        }
+        if (frame < this.fBufferSize) {
+            render(frame, this.fBufferSize - frame);
+        }
+    }
+
+    /**
+     * Point the wasm channel tables at frame `offset` of the block.
+     *
+     * Called by each slice rather than left set afterwards, so nothing outside
+     * a `compute` has to care where the last one left them.
+     */
+    protected setBufferOffset(offset: number) {
+        const bytes = offset * this.fSampleSize;
+        for (let chan = 0; chan < this.fInBase.length; chan++) {
+            this.fHEAP32[(this.fAudioInputs >> 2) + chan] =
+                this.fInBase[chan] + bytes;
+        }
+        for (let chan = 0; chan < this.fOutBase.length; chan++) {
+            this.fHEAP32[(this.fAudioOutputs >> 2) + chan] =
+                this.fOutBase[chan] + bytes;
+        }
     }
 
     // Tools
@@ -1634,6 +1735,22 @@ export class FaustMonoWebAudioDsp
     private fDSP!: number;
     private fSampleRate: number;
 
+    /**
+     * One slice of a block, for `renderBlock`.
+     *
+     * Built once rather than per call: `compute` runs on the audio thread and
+     * has no business allocating a closure every 128 frames.
+     */
+    private fRenderSlice = (offset: number, count: number) => {
+        this.setBufferOffset(offset);
+        this.fInstance.api.compute(
+            this.fDSP,
+            count,
+            this.fAudioInputs,
+            this.fAudioOutputs
+        );
+    };
+
     constructor(
         instance: FaustMonoDspInstance,
         sampleRate: number,
@@ -1760,6 +1877,19 @@ export class FaustMonoWebAudioDsp
             }
         }
 
+        // Remember where each channel starts. `setBufferOffset` moves the
+        // tables between slices, so after the first slice the tables no longer
+        // say where the block began.
+        this.fHEAP32 = HEAP32;
+        this.fInBase = [];
+        for (let chan = 0; chan < this.getNumInputs(); chan++) {
+            this.fInBase[chan] = HEAP32[(this.fAudioInputs >> 2) + chan];
+        }
+        this.fOutBase = [];
+        for (let chan = 0; chan < this.getNumOutputs(); chan++) {
+            this.fOutBase[chan] = HEAP32[(this.fAudioOutputs >> 2) + chan];
+        }
+
         return endMemory;
     }
 
@@ -1779,7 +1909,8 @@ export class FaustMonoWebAudioDsp
             | ((input: Float32Array[] | Float64Array[]) => any),
         output:
             | Float32Array[]
-            | ((output: Float32Array[] | Float64Array[]) => any)
+            | ((output: Float32Array[] | Float64Array[]) => any),
+        events?: FaustTimedEvent[]
     ) {
         // Check DSP state
         if (this.fDestroyed) return false;
@@ -1831,13 +1962,8 @@ export class FaustMonoWebAudioDsp
         // Possibly call an externally given callback (for instance to synchronize playing a MIDIFile...)
         if (this.fComputeHandler) this.fComputeHandler(this.fBufferSize);
 
-        // Compute
-        this.fInstance.api.compute(
-            this.fDSP,
-            this.fBufferSize,
-            this.fAudioInputs,
-            this.fAudioOutputs
-        );
+        // Compute, in slices around the timed events if there are any
+        this.renderBlock(events, this.fRenderSlice);
 
         // Update bargraph
         this.updateOutputs();
@@ -2063,7 +2189,10 @@ export class FaustWebAudioDspVoice {
         $outputZero: number,
         $outputsHalf: number
     ) {
-        const size = bufferSize / 2;
+        // `>> 1` rather than `/ 2`: a block rendered in slices hands this
+        // whatever the slice is long, odd counts included, and wasm counts
+        // whole frames. The second half takes the remainder so the two add up.
+        const size = bufferSize >> 1;
 
         // Reset envelops
         this.fGateLabel.forEach((index) =>
@@ -2077,7 +2206,7 @@ export class FaustWebAudioDspVoice {
         this.keyOn(this.fNextNote, this.fNextVel);
 
         // Compute on second half buffer
-        this.fAPI.compute(this.fDSP, size, $inputs, $outputsHalf);
+        this.fAPI.compute(this.fDSP, bufferSize - size, $inputs, $outputsHalf);
     }
 
     compute(bufferSize: number, $inputs: number, $outputs: number) {
@@ -2101,8 +2230,95 @@ export class FaustPolyWebAudioDsp
     private fJSONEffect: FaustDspMeta | null;
     private fAudioMixing!: number;
     private fAudioMixingHalf!: number;
+    private fMixingBase: number[] = [];
     private fVoiceTable: FaustWebAudioDspVoice[];
     private fSampleRate: number;
+
+    /**
+     * One slice of a block: clear the sum, render every live voice into it,
+     * then run the effect over it.
+     *
+     * Built once rather than per call, since `compute` runs on the audio
+     * thread. Everything it touches -- the mixer, the voice table, the effect
+     * -- takes a frame count already, so a slice is the same work over fewer
+     * frames rather than a different code path.
+     */
+    private fRenderSlice = (offset: number, count: number) => {
+        this.setBufferOffset(offset);
+        this.setMixingOffset(offset, count);
+        this.fInstance.mixerAPI.clearOutput(
+            count,
+            this.getNumOutputs(),
+            this.fAudioOutputs
+        );
+        this.fVoiceTable.forEach((voice) => {
+            if (voice.fCurNote === FaustWebAudioDspVoice.kLegatoVoice) {
+                // Play from current note and next note
+                voice.computeLegato(
+                    count,
+                    this.fAudioInputs,
+                    this.fAudioMixing,
+                    this.fAudioMixingHalf
+                );
+                // FadeOut on first half buffer
+                this.fInstance.mixerAPI.fadeOut(
+                    count >> 1,
+                    this.getNumOutputs(),
+                    this.fAudioMixing
+                );
+                // Mix it in result
+                voice.fLevel = this.fInstance.mixerAPI.mixCheckVoice(
+                    count,
+                    this.getNumOutputs(),
+                    this.fAudioMixing,
+                    this.fAudioOutputs
+                );
+            } else if (voice.fCurNote !== FaustWebAudioDspVoice.kFreeVoice) {
+                // Compute current note
+                voice.compute(count, this.fAudioInputs, this.fAudioMixing);
+                // Mix it in result
+                voice.fLevel = this.fInstance.mixerAPI.mixCheckVoice(
+                    count,
+                    this.getNumOutputs(),
+                    this.fAudioMixing,
+                    this.fAudioOutputs
+                );
+                // Check the level to possibly set the voice in kFreeVoice again
+                if (
+                    voice.fCurNote == FaustWebAudioDspVoice.kReleaseVoice &&
+                    voice.fLevel < FaustWebAudioDspVoice.VOICE_STOP_LEVEL
+                ) {
+                    voice.fCurNote = FaustWebAudioDspVoice.kFreeVoice;
+                }
+            }
+        });
+        if (this.fInstance.effectAPI)
+            this.fInstance.effectAPI.compute(
+                this.fEffect,
+                count,
+                this.fAudioOutputs,
+                this.fAudioOutputs
+            );
+    };
+
+    /**
+     * Move the mixing tables along with the input and output ones.
+     *
+     * `fAudioMixing` is where a voice renders before it is summed into the
+     * output, so it has to follow the slice. `fAudioMixingHalf` is the legato
+     * split point: inside the slice rather than at a fixed half of the block,
+     * on the same `count >> 1` that `computeLegato` uses.
+     */
+    private setMixingOffset(offset: number, count: number) {
+        const bytes = offset * this.fSampleSize;
+        const half = (offset + (count >> 1)) * this.fSampleSize;
+        for (let chan = 0; chan < this.fMixingBase.length; chan++) {
+            this.fHEAP32[(this.fAudioMixing >> 2) + chan] =
+                this.fMixingBase[chan] + bytes;
+            this.fHEAP32[(this.fAudioMixingHalf >> 2) + chan] =
+                this.fMixingBase[chan] + half;
+        }
+    }
 
     constructor(
         instance: FaustPolyDspInstance,
@@ -2285,6 +2501,21 @@ export class FaustPolyWebAudioDsp
             }
         }
 
+        // Remember where each channel starts. `setBufferOffset` moves the
+        // tables between slices, so after the first slice the tables no longer
+        // say where the block began.
+        this.fHEAP32 = HEAP32;
+        this.fInBase = [];
+        for (let chan = 0; chan < this.getNumInputs(); chan++) {
+            this.fInBase[chan] = HEAP32[(this.fAudioInputs >> 2) + chan];
+        }
+        this.fOutBase = [];
+        this.fMixingBase = [];
+        for (let chan = 0; chan < this.getNumOutputs(); chan++) {
+            this.fOutBase[chan] = HEAP32[(this.fAudioOutputs >> 2) + chan];
+            this.fMixingBase[chan] = HEAP32[(this.fAudioMixing >> 2) + chan];
+        }
+
         return endMemory;
     }
 
@@ -2385,7 +2616,11 @@ export class FaustPolyWebAudioDsp
     }
 
     // Public API
-    compute(input: Float32Array[], output: Float32Array[]) {
+    compute(
+        input: Float32Array[],
+        output: Float32Array[],
+        events?: FaustTimedEvent[]
+    ) {
         // Check DSP state
         if (this.fDestroyed) return false;
 
@@ -2431,64 +2666,8 @@ export class FaustPolyWebAudioDsp
         // Possibly call an externally given callback (for instance to synchronize playing a MIDIFile...)
         if (this.fComputeHandler) this.fComputeHandler(this.fBufferSize);
 
-        // Compute
-        this.fInstance.mixerAPI.clearOutput(
-            this.fBufferSize,
-            this.getNumOutputs(),
-            this.fAudioOutputs
-        );
-        this.fVoiceTable.forEach((voice) => {
-            if (voice.fCurNote === FaustWebAudioDspVoice.kLegatoVoice) {
-                // Play from current note and next note
-                voice.computeLegato(
-                    this.fBufferSize,
-                    this.fAudioInputs,
-                    this.fAudioMixing,
-                    this.fAudioMixingHalf
-                );
-                // FadeOut on first half buffer
-                this.fInstance.mixerAPI.fadeOut(
-                    this.fBufferSize / 2,
-                    this.getNumOutputs(),
-                    this.fAudioMixing
-                );
-                // Mix it in result
-                voice.fLevel = this.fInstance.mixerAPI.mixCheckVoice(
-                    this.fBufferSize,
-                    this.getNumOutputs(),
-                    this.fAudioMixing,
-                    this.fAudioOutputs
-                );
-            } else if (voice.fCurNote !== FaustWebAudioDspVoice.kFreeVoice) {
-                // Compute current note
-                voice.compute(
-                    this.fBufferSize,
-                    this.fAudioInputs,
-                    this.fAudioMixing
-                );
-                // Mix it in result
-                voice.fLevel = this.fInstance.mixerAPI.mixCheckVoice(
-                    this.fBufferSize,
-                    this.getNumOutputs(),
-                    this.fAudioMixing,
-                    this.fAudioOutputs
-                );
-                // Check the level to possibly set the voice in kFreeVoice again
-                if (
-                    voice.fCurNote == FaustWebAudioDspVoice.kReleaseVoice &&
-                    voice.fLevel < FaustWebAudioDspVoice.VOICE_STOP_LEVEL
-                ) {
-                    voice.fCurNote = FaustWebAudioDspVoice.kFreeVoice;
-                }
-            }
-        });
-        if (this.fInstance.effectAPI)
-            this.fInstance.effectAPI.compute(
-                this.fEffect,
-                this.fBufferSize,
-                this.fAudioOutputs,
-                this.fAudioOutputs
-            );
+        // Compute, in slices around the timed events if there are any
+        this.renderBlock(events, this.fRenderSlice);
 
         // Update bargraph
         this.updateOutputs();

--- a/src/FaustWebAudioDsp.ts
+++ b/src/FaustWebAudioDsp.ts
@@ -751,8 +751,29 @@ export interface IFaustBaseWebAudioDsp {
 }
 
 export type IFaustMonoWebAudioDsp = IFaustBaseWebAudioDsp;
+
+/**
+ * A node's controls, each with the instant it takes effect.
+ *
+ * `time` is AudioContext seconds -- the clock `AudioParam.setValueAtTime`
+ * takes -- so a note and a parameter ramp can be scheduled against one
+ * another. It is declared here, on the node, rather than on
+ * `IFaustBaseWebAudioDsp`, because it is a node's to offer: a node reaches
+ * its DSP across a message port and can hold a control write until the block
+ * that contains the instant, where a DSP is already inside the block by the
+ * time anyone asks it for anything.
+ *
+ * An AudioWorklet node lands the control on the sample it named. A
+ * ScriptProcessor node (`sp: true`) has no such queue and applies it on
+ * arrival, as it always did: the argument is accepted and ignored there.
+ */
 export interface IFaustMonoWebAudioNode
-    extends IFaustMonoWebAudioDsp, AudioNode {}
+    extends IFaustMonoWebAudioDsp, AudioNode {
+    midiMessage(data: number[] | Uint8Array, time?: number): void;
+    ctrlChange(chan: number, ctrl: number, value: number, time?: number): void;
+    pitchWheel(chan: number, value: number, time?: number): void;
+    setParamValue(path: string, value: number, time?: number): void;
+}
 
 export interface IFaustPolyWebAudioDsp extends IFaustBaseWebAudioDsp {
     /**
@@ -780,8 +801,26 @@ export interface IFaustPolyWebAudioDsp extends IFaustBaseWebAudioDsp {
      */
     allNotesOff(hard: boolean): void;
 }
+/** As `IFaustMonoWebAudioNode`, with the notes timestamped too. */
 export interface IFaustPolyWebAudioNode
-    extends IFaustPolyWebAudioDsp, AudioNode {}
+    extends IFaustPolyWebAudioDsp, AudioNode {
+    midiMessage(data: number[] | Uint8Array, time?: number): void;
+    ctrlChange(chan: number, ctrl: number, value: number, time?: number): void;
+    pitchWheel(chan: number, value: number, time?: number): void;
+    setParamValue(path: string, value: number, time?: number): void;
+    keyOn(
+        channel: number,
+        pitch: number,
+        velocity: number,
+        time?: number
+    ): void;
+    keyOff(
+        channel: number,
+        pitch: number,
+        velocity: number,
+        time?: number
+    ): void;
+}
 
 export class FaustBaseWebAudioDsp implements IFaustBaseWebAudioDsp {
     protected fOutputHandler: OutputParamHandler | null = null;
@@ -1089,6 +1128,21 @@ export class FaustBaseWebAudioDsp implements IFaustBaseWebAudioDsp {
         if (frame < this.fBufferSize) {
             render(frame, this.fBufferSize - frame);
         }
+    }
+
+    /**
+     * Perform every event without rendering anything.
+     *
+     * A block the DSP declines to render still has to take its control
+     * writes. They were taken off the queue to be applied here, so a `keyOn`
+     * dropped because the node was stopped, or because an input was not
+     * connected yet, is a note that never sounds and never will -- and the
+     * DSP's cached parameter values would go on disagreeing with the host's.
+     * Only a destroyed DSP drops them, which is the point of destroying it.
+     */
+    protected applyEvents(events?: FaustTimedEvent[]) {
+        if (!events) return;
+        for (let i = 0; i < events.length; i++) events[i].apply();
     }
 
     /**
@@ -1916,7 +1970,10 @@ export class FaustMonoWebAudioDsp
         if (this.fDestroyed) return false;
 
         // Check Processing state: the node returns 'true' to stay in the graph, even if not processing
-        if (!this.fProcessing) return true;
+        if (!this.fProcessing) {
+            this.applyEvents(events);
+            return true;
+        }
 
         // Init memory again on first call (since WebAssembly.memory.grow() may have been called)
         if (this.fFirstCall) {
@@ -1934,6 +1991,7 @@ export class FaustMonoWebAudioDsp
                 (!input || !input[0] || input[0].length === 0)
             ) {
                 // console.log("Process input error");
+                this.applyEvents(events);
                 return true;
             }
 
@@ -1944,6 +2002,7 @@ export class FaustMonoWebAudioDsp
                 (!output || !output[0] || output[0].length === 0)
             ) {
                 // console.log("Process output error");
+                this.applyEvents(events);
                 return true;
             }
 
@@ -2235,62 +2294,53 @@ export class FaustPolyWebAudioDsp
     private fSampleRate: number;
 
     /**
-     * One slice of a block: clear the sum, render every live voice into it,
-     * then run the effect over it.
+     * The voices whose crossfade this block already rendered whole.
+     *
+     * Reused rather than rebuilt: `compute` runs on the audio thread, and a
+     * steal is rare enough that this is almost always empty.
+     */
+    private fStolen: FaustWebAudioDspVoice[] = [];
+
+    /**
+     * One slice of a block: render every live voice into the sum, then run
+     * the effect over it.
      *
      * Built once rather than per call, since `compute` runs on the audio
      * thread. Everything it touches -- the mixer, the voice table, the effect
      * -- takes a frame count already, so a slice is the same work over fewer
      * frames rather than a different code path.
+     *
+     * The sum is cleared once for the block rather than once per slice, and
+     * the voices whose note was stolen were rendered across the whole block
+     * before the first slice, so this leaves them alone. A voice that becomes
+     * `kLegatoVoice` partway through the block is not one of them: it keeps
+     * playing the note it is losing for the rest of the block and takes its
+     * crossfade at the top of the next one, exactly as it did when a `keyOn`
+     * could only ever arrive between two blocks.
      */
     private fRenderSlice = (offset: number, count: number) => {
         this.setBufferOffset(offset);
         this.setMixingOffset(offset, count);
-        this.fInstance.mixerAPI.clearOutput(
-            count,
-            this.getNumOutputs(),
-            this.fAudioOutputs
-        );
         this.fVoiceTable.forEach((voice) => {
-            if (voice.fCurNote === FaustWebAudioDspVoice.kLegatoVoice) {
-                // Play from current note and next note
-                voice.computeLegato(
-                    count,
-                    this.fAudioInputs,
-                    this.fAudioMixing,
-                    this.fAudioMixingHalf
-                );
-                // FadeOut on first half buffer
-                this.fInstance.mixerAPI.fadeOut(
-                    count >> 1,
-                    this.getNumOutputs(),
-                    this.fAudioMixing
-                );
-                // Mix it in result
-                voice.fLevel = this.fInstance.mixerAPI.mixCheckVoice(
-                    count,
-                    this.getNumOutputs(),
-                    this.fAudioMixing,
-                    this.fAudioOutputs
-                );
-            } else if (voice.fCurNote !== FaustWebAudioDspVoice.kFreeVoice) {
-                // Compute current note
-                voice.compute(count, this.fAudioInputs, this.fAudioMixing);
-                // Mix it in result
-                voice.fLevel = this.fInstance.mixerAPI.mixCheckVoice(
-                    count,
-                    this.getNumOutputs(),
-                    this.fAudioMixing,
-                    this.fAudioOutputs
-                );
-                // Check the level to possibly set the voice in kFreeVoice again
-                if (
-                    voice.fCurNote == FaustWebAudioDspVoice.kReleaseVoice &&
-                    voice.fLevel < FaustWebAudioDspVoice.VOICE_STOP_LEVEL
-                ) {
-                    voice.fCurNote = FaustWebAudioDspVoice.kFreeVoice;
-                }
-            }
+            if (voice.fCurNote === FaustWebAudioDspVoice.kFreeVoice) return;
+            if (this.fStolen.length && this.fStolen.indexOf(voice) !== -1)
+                return;
+            // Compute current note
+            voice.compute(count, this.fAudioInputs, this.fAudioMixing);
+            // Mix it in result
+            const level = this.fInstance.mixerAPI.mixCheckVoice(
+                count,
+                this.getNumOutputs(),
+                this.fAudioMixing,
+                this.fAudioOutputs
+            );
+            // The loudest the voice got anywhere in the block. Whether a
+            // release has died away is a question about the block: a slice of
+            // a few frames landing on a zero crossing reads nothing from a
+            // voice that is still plainly sounding, and freeing it there cuts
+            // the tail off. The check itself waits until `compute` has the
+            // whole block, below.
+            if (level > voice.fLevel) voice.fLevel = level;
         });
         if (this.fInstance.effectAPI)
             this.fInstance.effectAPI.compute(
@@ -2300,6 +2350,46 @@ export class FaustPolyWebAudioDsp
                 this.fAudioOutputs
             );
     };
+
+    /**
+     * Render the voices whose note was stolen, across the whole block.
+     *
+     * A steal is a crossfade: the voice renders the note it is losing over the
+     * first half of the buffer, that half is faded out, and the note it is
+     * taking renders the second half. Half of a *block* -- 64 frames -- and
+     * not half of whatever slice the voice happens to fall in, which late in a
+     * sliced block is a fade of one or two frames, or of none at all, which is
+     * a click. So this runs before the slicing, over the full block, and the
+     * slices skip these voices.
+     */
+    private renderStolenVoices() {
+        const stolen = this.fStolen;
+        stolen.length = 0;
+        this.fVoiceTable.forEach((voice) => {
+            if (voice.fCurNote !== FaustWebAudioDspVoice.kLegatoVoice) return;
+            stolen.push(voice);
+            // Play from current note and next note
+            voice.computeLegato(
+                this.fBufferSize,
+                this.fAudioInputs,
+                this.fAudioMixing,
+                this.fAudioMixingHalf
+            );
+            // FadeOut on first half buffer
+            this.fInstance.mixerAPI.fadeOut(
+                this.fBufferSize >> 1,
+                this.getNumOutputs(),
+                this.fAudioMixing
+            );
+            // Mix it in result
+            voice.fLevel = this.fInstance.mixerAPI.mixCheckVoice(
+                this.fBufferSize,
+                this.getNumOutputs(),
+                this.fAudioMixing,
+                this.fAudioOutputs
+            );
+        });
+    }
 
     /**
      * Move the mixing tables along with the input and output ones.
@@ -2631,7 +2721,10 @@ export class FaustPolyWebAudioDsp
         }
 
         // Check Processing state: the node returns 'true' to stay in the graph, even if not processing
-        if (!this.fProcessing) return true;
+        if (!this.fProcessing) {
+            this.applyEvents(events);
+            return true;
+        }
 
         // Check inputs
         if (
@@ -2639,6 +2732,7 @@ export class FaustPolyWebAudioDsp
             (!input || !input[0] || input[0].length === 0)
         ) {
             // console.log("Process input error");
+            this.applyEvents(events);
             return true;
         }
 
@@ -2648,6 +2742,7 @@ export class FaustPolyWebAudioDsp
             (!output || !output[0] || output[0].length === 0)
         ) {
             // console.log("Process output error");
+            this.applyEvents(events);
             return true;
         }
 
@@ -2666,8 +2761,32 @@ export class FaustPolyWebAudioDsp
         // Possibly call an externally given callback (for instance to synchronize playing a MIDIFile...)
         if (this.fComputeHandler) this.fComputeHandler(this.fBufferSize);
 
+        // Clear the sum once for the block, not once per slice: a stolen
+        // voice writes its whole crossfade into it before the slices start,
+        // and a slice clearing its own range would wipe part of that.
+        this.setBufferOffset(0);
+        this.setMixingOffset(0, this.fBufferSize);
+        this.fInstance.mixerAPI.clearOutput(
+            this.fBufferSize,
+            this.getNumOutputs(),
+            this.fAudioOutputs
+        );
+        this.fVoiceTable.forEach((voice) => (voice.fLevel = 0));
+        this.renderStolenVoices();
+
         // Compute, in slices around the timed events if there are any
         this.renderBlock(events, this.fRenderSlice);
+
+        // A voice in release whose level never rose above the threshold
+        // anywhere in the block has died away, and its slot goes back.
+        this.fVoiceTable.forEach((voice) => {
+            if (
+                voice.fCurNote === FaustWebAudioDspVoice.kReleaseVoice &&
+                voice.fLevel < FaustWebAudioDspVoice.VOICE_STOP_LEVEL
+            ) {
+                voice.fCurNote = FaustWebAudioDspVoice.kFreeVoice;
+            }
+        });
 
         // Update bargraph
         this.updateOutputs();

--- a/src/FaustWebAudioDsp.ts
+++ b/src/FaustWebAudioDsp.ts
@@ -30,18 +30,10 @@ export type PlotHandler = (
 export type MetadataHandler = (key: string, value: string) => void;
 
 /**
- * A control write due at a known frame inside the next block.
+ * A control write to perform at a given frame of the block being rendered.
  *
- * Given a list of these, `compute` renders the block in slices: up to the
- * frame of the next event, apply it, carry on. The same approach as
- * `architecture/faust/dsp/timed-dsp.h`, which is how a native host gets
- * sample-accurate MIDI.
- *
- * `apply` is a closure rather than a `{ path, value }` pair so one list can
- * carry parameter writes, `keyOn`s and MIDI messages together. The caller
- * knows how to perform each; the DSP only needs to know when.
- *
- * The list must be sorted by frame. Frames outside the block are clamped.
+ * Passed to `compute` as a list sorted by frame. Frames outside the block are
+ * clamped into it.
  */
 export interface FaustTimedEvent {
     /** Frame offset from the start of the block, 0 <= frame < bufferSize */
@@ -750,18 +742,9 @@ export interface IFaustBaseWebAudioDsp {
 export type IFaustMonoWebAudioDsp = IFaustBaseWebAudioDsp;
 
 /**
- * A node's controls, each taking an optional time.
+ * A node's controls, each taking an optional `time` in AudioContext seconds.
  *
- * `time` is in AudioContext seconds, the same clock as
- * `AudioParam.setValueAtTime`, so notes and parameter automation can be
- * scheduled against each other.
- *
- * It is declared on the node rather than on `IFaustBaseWebAudioDsp` because
- * only a node can honour it: it reaches its DSP over a message port and can
- * hold the write until the right block. A DSP is called from inside the block
- * and has nowhere to put a future event.
- *
- * An AudioWorklet node applies the control on the exact sample. A
+ * An AudioWorklet node applies the control on that exact sample. A
  * ScriptProcessor node (`sp: true`) accepts `time` and ignores it.
  */
 export interface IFaustMonoWebAudioNode
@@ -854,14 +837,8 @@ export class FaustBaseWebAudioDsp implements IFaustBaseWebAudioDsp {
     protected fAudioOutputs!: number;
 
     /**
-     * Block-start address of every wasm audio channel, plus the heap view
-     * holding the pointer tables.
-     *
-     * Rendering a slice means giving wasm a channel pointer to the slice's
-     * first frame, so `setBufferOffset` rewrites the tables and needs these
-     * unmoved addresses to offset from. Only the tables move; the
-     * `fInChannels` / `fOutChannels` views from `initMemory` still span the
-     * whole block and stay valid.
+     * Block-start address of every wasm audio channel, and the heap view
+     * holding the pointer tables. `setBufferOffset` offsets from these.
      */
     protected fInBase: number[] = [];
     protected fOutBase: number[] = [];
@@ -1090,14 +1067,13 @@ export class FaustBaseWebAudioDsp implements IFaustBaseWebAudioDsp {
     }
 
     /**
-     * Render a whole block through `render`, stopping at each event.
+     * Render a block in slices, applying each event at its frame.
      *
-     * Render up to the next event's frame, apply it, continue. Living in the
-     * base class means mono and poly only have to supply what rendering a
-     * slice means.
+     * Calls `render(offset, count)` for the audio between events. With no
+     * events the block is rendered as one slice.
      *
-     * With no events the block is one slice, which is what every caller that
-     * passes no events gets.
+     * @param events - sorted by frame; frames are clamped into the block
+     * @param render - renders `count` frames starting at `offset`
      */
     protected renderBlock(
         events: FaustTimedEvent[] | undefined,
@@ -1110,11 +1086,10 @@ export class FaustBaseWebAudioDsp implements IFaustBaseWebAudioDsp {
         let frame = 0;
         for (let i = 0; i < events.length; i++) {
             const event = events[i];
-            // Clamped, not trusted: a frame past the end of the block would
-            // give wasm a count that runs off the end of the channel.
+            // Clamp: a frame past the end of the block would give wasm a
+            // count that runs off the end of the channel.
             const at = Math.min(Math.max(event.frame, 0), this.fBufferSize);
-            // Two events on one frame leave an empty slice between them,
-            // which is not worth a wasm call.
+            // Two events on one frame leave an empty slice between them.
             if (at > frame) {
                 render(frame, at - frame);
                 frame = at;
@@ -1127,27 +1102,17 @@ export class FaustBaseWebAudioDsp implements IFaustBaseWebAudioDsp {
     }
 
     /**
-     * Apply every event without rendering.
+     * Apply every event without rendering any audio.
      *
-     * For the blocks `compute` returns early from: stopped, or an input or
-     * output not connected yet. The events have already left the processor's
-     * queue, so dropping them here loses them permanently -- a `keyOn` that
-     * never sounds, or a parameter the DSP and the host disagree about from
-     * then on.
-     *
-     * A destroyed DSP is the exception, and does drop them.
+     * Used by `compute` on the blocks it returns early from, so that a block
+     * which is not rendered still takes its control writes.
      */
     protected applyEvents(events?: FaustTimedEvent[]) {
         if (!events) return;
         for (let i = 0; i < events.length; i++) events[i].apply();
     }
 
-    /**
-     * Point the wasm channel tables at frame `offset` of the block.
-     *
-     * Each slice sets this before rendering, so nothing outside `compute`
-     * depends on where the previous slice left the tables.
-     */
+    /** Point the wasm channel tables at frame `offset` of the block. */
     protected setBufferOffset(offset: number) {
         const bytes = offset * this.fSampleSize;
         for (let chan = 0; chan < this.fInBase.length; chan++) {
@@ -1786,12 +1751,7 @@ export class FaustMonoWebAudioDsp
     private fDSP!: number;
     private fSampleRate: number;
 
-    /**
-     * Render one slice, for `renderBlock`.
-     *
-     * A field rather than an inline closure so it is allocated once instead of
-     * on every `compute` call.
-     */
+    /** Render `count` frames of this DSP, starting at frame `offset`. */
     private fRenderSlice = (offset: number, count: number) => {
         this.setBufferOffset(offset);
         this.fInstance.api.compute(
@@ -1928,8 +1888,7 @@ export class FaustMonoWebAudioDsp
             }
         }
 
-        // Record where each channel starts: `setBufferOffset` overwrites the
-        // tables between slices, so they stop being a record of that.
+        // Record where each channel starts, before any slice moves the tables.
         this.fHEAP32 = HEAP32;
         this.fInBase = [];
         for (let chan = 0; chan < this.getNumInputs(); chan++) {
@@ -2244,8 +2203,8 @@ export class FaustWebAudioDspVoice {
         $outputZero: number,
         $outputsHalf: number
     ) {
-        // `>> 1` rather than `/ 2` because `bufferSize` need not be even, and
-        // wasm counts whole frames. The second half takes the remainder.
+        // `>> 1` because `bufferSize` need not be even and wasm counts whole
+        // frames; the second half takes the remainder.
         const size = bufferSize >> 1;
 
         // Reset envelops
@@ -2288,24 +2247,20 @@ export class FaustPolyWebAudioDsp
     private fVoiceTable: FaustWebAudioDspVoice[];
     private fSampleRate: number;
 
-    /** Voices whose crossfade this block already rendered in full. */
+    /** Voices whose crossfade `renderStolenVoices` rendered for this block. */
     private fStolen: FaustWebAudioDspVoice[] = [];
 
     /**
-     * Render one slice: every live voice into the sum, then the effect.
+     * Render `count` frames starting at `offset`: every live voice into the
+     * sum, then the effect over it.
      *
-     * The mixer, the voices and the effect all take a frame count, so a slice
-     * is the same work over fewer frames. A field rather than an inline
-     * closure so it is allocated once instead of on every `compute` call.
+     * Skips the voices in `fStolen`, which `renderStolenVoices` has already
+     * rendered for the whole block. `compute` clears the sum once per block
+     * rather than per slice.
      *
-     * Two things `compute` does around this. The sum is cleared once for the
-     * block, not per slice, because `renderStolenVoices` has already written
-     * across the whole of it. And those stolen voices are skipped here.
-     *
-     * A voice that becomes `kLegatoVoice` partway through the block is not one
-     * of them: it plays out the note it is losing and crossfades at the top of
-     * the next block, as it did when a `keyOn` could only arrive between
-     * blocks.
+     * A voice that becomes `kLegatoVoice` partway through a block keeps
+     * playing its current note here, and crossfades at the top of the next
+     * block.
      */
     private fRenderSlice = (offset: number, count: number) => {
         this.setBufferOffset(offset);
@@ -2323,10 +2278,8 @@ export class FaustPolyWebAudioDsp
                 this.fAudioMixing,
                 this.fAudioOutputs
             );
-            // Keep the loudest level from any slice. A few frames landing on
-            // a zero crossing read near silence from a voice that is still
-            // sounding, so `compute` decides whether a release has finished
-            // once the whole block is done.
+            // Keep the loudest level from any slice; `compute` decides
+            // whether a release has finished once the block is complete.
             if (level > voice.fLevel) voice.fLevel = level;
         });
         if (this.fInstance.effectAPI)
@@ -2339,14 +2292,12 @@ export class FaustPolyWebAudioDsp
     };
 
     /**
-     * Render the stolen voices, each across the whole block.
+     * Render every `kLegatoVoice` across the whole block, crossfading from the
+     * note it is losing to the note it is taking over half the buffer.
      *
-     * A steal is a crossfade: the voice plays the note it is losing over the
-     * first half of the buffer, that half fades out, and the new note plays
-     * the second half. The fade has to be half a block -- 64 frames -- rather
-     * than half a slice, which late in the block would be a frame or two, or
-     * nothing at all. So this runs before the slicing, and `fRenderSlice`
-     * skips these voices.
+     * Runs before the block is sliced, and records the voices in `fStolen` so
+     * `fRenderSlice` skips them. Rendering whole keeps the crossfade half a
+     * block rather than half of whatever slice the voice fell in.
      */
     private renderStolenVoices() {
         const stolen = this.fStolen;
@@ -2378,12 +2329,11 @@ export class FaustPolyWebAudioDsp
     }
 
     /**
-     * Move the mixing tables along with the input and output ones.
+     * Point the mixing tables at frame `offset` of the block.
      *
      * `fAudioMixing` is where a voice renders before being summed into the
-     * output, so it follows the slice. `fAudioMixingHalf` is the crossfade
-     * split point, `count >> 1` frames in, matching `computeLegato`. Only
-     * `renderStolenVoices` uses it, and always with the whole block.
+     * output. `fAudioMixingHalf` is the crossfade split point, `count >> 1`
+     * frames further in, matching `computeLegato`.
      */
     private setMixingOffset(offset: number, count: number) {
         const bytes = offset * this.fSampleSize;
@@ -2577,8 +2527,7 @@ export class FaustPolyWebAudioDsp
             }
         }
 
-        // Record where each channel starts: `setBufferOffset` overwrites the
-        // tables between slices, so they stop being a record of that.
+        // Record where each channel starts, before any slice moves the tables.
         this.fHEAP32 = HEAP32;
         this.fInBase = [];
         for (let chan = 0; chan < this.getNumInputs(); chan++) {
@@ -2746,9 +2695,8 @@ export class FaustPolyWebAudioDsp
         // Possibly call an externally given callback (for instance to synchronize playing a MIDIFile...)
         if (this.fComputeHandler) this.fComputeHandler(this.fBufferSize);
 
-        // Clear the sum once for the block, not per slice: the stolen voices
-        // below write across the whole of it, and a slice clearing its own
-        // range afterwards would erase part of that.
+        // Cleared once for the block, not per slice: the stolen voices below
+        // write across the whole of it.
         this.setBufferOffset(0);
         this.setMixingOffset(0, this.fBufferSize);
         this.fInstance.mixerAPI.clearOutput(
@@ -2762,8 +2710,7 @@ export class FaustPolyWebAudioDsp
         // Compute -- in slices around the events, if there are any
         this.renderBlock(events, this.fRenderSlice);
 
-        // A releasing voice that stayed below the threshold for every slice
-        // has died away, and its slot is free again.
+        // Free the releasing voices that stayed below the threshold.
         this.fVoiceTable.forEach((voice) => {
             if (
                 voice.fCurNote === FaustWebAudioDspVoice.kReleaseVoice &&

--- a/test/timing/measure.mjs
+++ b/test/timing/measure.mjs
@@ -4,34 +4,32 @@
  *   npm run measure
  *   npm run measure -- --runtime ../faustwasm-master/dist/esm/index.js
  *
- * The unit tests under test/unit cover the arithmetic -- the queue, the
- * automation walk, the slicing -- in plain Node. This is the other half: a
- * real AudioWorklet, in a real browser, rendering offline, so what is measured
- * is the frame a control actually took effect on rather than the frame the
- * code meant to give it.
+ * The unit tests under test/unit cover the arithmetic in plain Node. This is
+ * the other half: a real AudioWorklet in a real browser, rendering offline, so
+ * what gets measured is the frame a control took effect on rather than the
+ * frame the code intended.
  *
  * The device under test is compiled here and is one line:
  *
  *   process = button("gate");
  *
- * so the rendered signal *is* the gate, and an onset is a sample that went
- * from 0 to 1 rather than something a threshold had to be talked into. What is
- * being measured is the wrapper -- when it applies a control -- and a DSP with
- * an envelope on it would only add its own attack to every number below.
+ * so the rendered signal is the gate itself, and an onset is a sample that
+ * went from 0 to 1 -- no threshold to tune. What is under test is the wrapper,
+ * and a DSP with an envelope would only add its attack to every number below.
  *
- * Three things are measured:
+ * Three measurements:
  *
- *   onsets     gate.setValueAtTime(1, t) at deliberately non-block-aligned t
+ *   onsets     gate.setValueAtTime(1, t) at non-block-aligned t
  *   retrigger  the same, with the gate dropped a few samples before the next
- *              hit so the 1 -> 0 -> 1 falls inside a single 128-frame block
+ *              hit so the 1 -> 0 -> 1 falls inside one 128-frame block
  *   keyOn      a polyphonic voice triggered by keyOn(ch, note, vel, time)
  *
- * Against 0.17.1 as published the first is out by 0 to 127 frames, the second
+ * Against 0.17.1 as published, the first is 0 to 127 frames late, the second
  * loses every hit whose gate drop shares a block with the hit after it, and
- * the third has no `time` argument to pass. Pass --runtime to point this at
- * that build and see it; without one it measures dist/esm/index.js.
+ * the third has no `time` to pass. Point --runtime at that build to see it;
+ * without it, dist/esm/index.js is measured.
  *
- * Chromium comes from Playwright, which is not a dependency of this package --
+ * Chromium comes from Playwright, which is not a dependency of this package:
  * `npm i -D playwright && npx playwright install chromium` to run this.
  */
 import {
@@ -50,16 +48,16 @@ const SAMPLE_RATE = 48000;
 const QUANTUM = 128;
 
 /**
- * 6000 frames is 46.875 blocks, so the hits walk through every phase of the
- * block instead of landing on the one alignment that would pass by luck.
+ * 6000 frames is 46.875 blocks, so the hits move through every phase of the
+ * block rather than landing on the one alignment that would pass by luck.
  */
 const SPACING = 6000;
 const HITS = 16;
 
-/** Wide enough that the gate is unambiguously down before the next hit. */
+/** Wide enough that the gate is clearly down before the next hit. */
 const GATE_WIDTH = 3 * QUANTUM;
 
-/** Tight enough that the drop and the next hit usually share a block. */
+/** Tight enough that the drop and the next hit share a block. */
 const TIGHT_GAP = 8;
 
 const runtimeArg = process.argv.indexOf('--runtime');
@@ -159,8 +157,8 @@ let failed = false;
 for (const [name, onsets] of Object.entries(measured)) {
     if (onsets.error) {
         console.log(`  ${name.padEnd(10)} unavailable: ${onsets.error}`);
-        // A runtime with no `time` argument to pass cannot be asked this
-        // question, which is the finding rather than a failure of the harness.
+        // A runtime with no `time` to pass cannot be asked this question.
+        // That is the finding, not a broken harness.
         if (name !== 'keyOn') failed = true;
         continue;
     }
@@ -193,9 +191,9 @@ process.exit(failed ? 1 : 0);
 /**
  * Everything below runs in the page.
  *
- * It is one function because `page.evaluate` serialises it: nothing outside
- * its own body is in scope there, config included, which is why that arrives
- * as an argument.
+ * One function, because `page.evaluate` serialises it and nothing outside its
+ * body is in scope over there -- which is why the config arrives as an
+ * argument.
  */
 async function measure({
     sampleRate,
@@ -227,9 +225,9 @@ async function measure({
      * The frames where the rendered gate went up.
      *
      * The render starts from silence, so frame 0 counts as an edge if the gate
-     * is already up there -- a hit scheduled on the first sample is the one
-     * alignment every implementation gets right, and leaving it out would hide
-     * the off-by-one it produces in everything after it.
+     * is already up. A hit on the first sample is the one alignment every
+     * implementation gets right, and omitting it would shift every later hit
+     * by one and hide the error.
      */
     const risingEdges = (buffer) => {
         const data = buffer.getChannelData(0);
@@ -247,15 +245,15 @@ async function measure({
 
     const monoFactory = await load('probe');
 
-    /** Schedule the gate as an AudioParam, the way a mono voice is played. */
+    /** Schedule the gate as an AudioParam, the way a mono voice plays. */
     const renderMono = async (gap) => {
         const ctx = context();
         const generator = new runtime.FaustMonoDspGenerator();
         generator.name = 'probe';
         const node = await generator.createNode(ctx, 'probe', {
             ...monoFactory,
-            // A fresh key per render, or the second one reuses the worklet
-            // processor the first one registered and its AudioParams with it.
+            // A fresh key per render: otherwise the second reuses the worklet
+            // processor the first registered, AudioParams included.
             shaKey: `probe-${gap}`
         });
         node.connect(ctx.destination);
@@ -285,9 +283,9 @@ async function measure({
         results.retrigger = { error: String(e.message || e) };
     }
 
-    // A polyphonic voice takes its trigger by message rather than as an
-    // AudioParam -- `gate` is one of the paths the poly wrapper reserves -- so
-    // this is the half of the question `setValueAtTime` cannot ask.
+    // A polyphonic voice is triggered by message, not by AudioParam: `gate`
+    // is one of the paths the poly wrapper reserves. So this is the half of
+    // the question `setValueAtTime` cannot ask.
     try {
         const polyFactory = await load('probe-poly');
         const mixer = await WebAssembly.compile(
@@ -312,9 +310,9 @@ async function measure({
             node.keyOn(0, 60, 100, on / sampleRate);
             node.keyOff(0, 60, 0, (on + gateWidth) / sampleRate);
         }
-        // The messages have to be across the port before rendering starts:
-        // OfflineAudioContext renders as fast as it can and does not wait for
-        // one.
+        // The messages must cross the port before rendering starts:
+        // OfflineAudioContext renders as fast as it can and waits for
+        // nothing.
         await new Promise((resolve) => setTimeout(resolve, 100 + quantum));
         results.keyOn = risingEdges(await ctx.startRendering());
     } catch (e) {

--- a/test/timing/measure.mjs
+++ b/test/timing/measure.mjs
@@ -1,0 +1,330 @@
+/**
+ * Ask a Faust device to sound on a particular sample, and check that it did.
+ *
+ *   npm run measure
+ *   npm run measure -- --runtime ../faustwasm-master/dist/esm/index.js
+ *
+ * The unit tests under test/unit cover the arithmetic -- the queue, the
+ * automation walk, the slicing -- in plain Node. This is the other half: a
+ * real AudioWorklet, in a real browser, rendering offline, so what is measured
+ * is the frame a control actually took effect on rather than the frame the
+ * code meant to give it.
+ *
+ * The device under test is compiled here and is one line:
+ *
+ *   process = button("gate");
+ *
+ * so the rendered signal *is* the gate, and an onset is a sample that went
+ * from 0 to 1 rather than something a threshold had to be talked into. What is
+ * being measured is the wrapper -- when it applies a control -- and a DSP with
+ * an envelope on it would only add its own attack to every number below.
+ *
+ * Three things are measured:
+ *
+ *   onsets     gate.setValueAtTime(1, t) at deliberately non-block-aligned t
+ *   retrigger  the same, with the gate dropped a few samples before the next
+ *              hit so the 1 -> 0 -> 1 falls inside a single 128-frame block
+ *   keyOn      a polyphonic voice triggered by keyOn(ch, note, vel, time)
+ *
+ * Against 0.17.1 as published the first is out by 0 to 127 frames, the second
+ * loses every hit whose gate drop shares a block with the hit after it, and
+ * the third has no `time` argument to pass. Pass --runtime to point this at
+ * that build and see it; without one it measures dist/esm/index.js.
+ *
+ * Chromium comes from Playwright, which is not a dependency of this package --
+ * `npm i -D playwright && npx playwright install chromium` to run this.
+ */
+import {
+    instantiateFaustModuleFromFile,
+    LibFaust,
+    FaustCompiler
+} from '../../dist/esm/index.js';
+import { createServer } from 'node:http';
+import { readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const SAMPLE_RATE = 48000;
+const QUANTUM = 128;
+
+/**
+ * 6000 frames is 46.875 blocks, so the hits walk through every phase of the
+ * block instead of landing on the one alignment that would pass by luck.
+ */
+const SPACING = 6000;
+const HITS = 16;
+
+/** Wide enough that the gate is unambiguously down before the next hit. */
+const GATE_WIDTH = 3 * QUANTUM;
+
+/** Tight enough that the drop and the next hit usually share a block. */
+const TIGHT_GAP = 8;
+
+const runtimeArg = process.argv.indexOf('--runtime');
+const RUNTIME = resolve(
+    ROOT,
+    runtimeArg === -1 ? 'dist/esm/index.js' : process.argv[runtimeArg + 1]
+);
+
+const PROBE = `declare name "Probe";
+process = button("gate");
+`;
+
+let chromium;
+try {
+    ({ chromium } = await import('playwright'));
+} catch {
+    fail(
+        'This needs a browser, and Playwright is not a dependency of this package:\n' +
+            '  npm i -D playwright && npx playwright install chromium'
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Compile the probe, and lift the voice mixer out of libfaust
+
+const faustModule = await instantiateFaustModuleFromFile(
+    join(ROOT, 'libfaust-wasm', 'libfaust-wasm.js')
+);
+const compiler = new FaustCompiler(new LibFaust(faustModule));
+
+const mono = await compiler.createMonoDSPFactory('probe', PROBE, '-ftz 2');
+if (!mono) fail(`probe failed to compile:\n${compiler.getErrorMessage()}`);
+const poly = await compiler.createPolyDSPFactory('probe', PROBE, '-ftz 2');
+if (!poly) fail(`probe poly failed to compile:\n${compiler.getErrorMessage()}`);
+const mixer = compiler
+    .fs()
+    .readFile('/usr/rsrc/mixer32.wasm', { encoding: 'binary' });
+
+// ---------------------------------------------------------------------------
+// Serve it, plus the runtime under test
+
+const files = {
+    '/faustwasm.js': ['text/javascript', readFileSync(RUNTIME)],
+    '/probe.wasm': ['application/wasm', Buffer.from(mono.code)],
+    '/probe.json': ['application/json', Buffer.from(mono.json)],
+    '/probe-poly.wasm': ['application/wasm', Buffer.from(poly.code)],
+    '/probe-poly.json': ['application/json', Buffer.from(poly.json)],
+    '/mixer32.wasm': ['application/wasm', Buffer.from(mixer)],
+    // An AudioWorklet needs a document, and a module script needs an origin.
+    '/': ['text/html', Buffer.from('<!doctype html><meta charset=utf-8>')]
+};
+
+const server = createServer((req, res) => {
+    const entry = files[req.url];
+    if (!entry) {
+        res.writeHead(404).end();
+        return;
+    }
+    res.writeHead(200, { 'content-type': entry[0] }).end(entry[1]);
+});
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const origin = `http://127.0.0.1:${server.address().port}`;
+
+// ---------------------------------------------------------------------------
+// Render
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+page.on('console', (m) => {
+    if (m.type() === 'error') console.error(`  page: ${m.text()}`);
+});
+await page.goto(origin);
+
+const measured = await page.evaluate(measure, {
+    sampleRate: SAMPLE_RATE,
+    spacing: SPACING,
+    hits: HITS,
+    gateWidth: GATE_WIDTH,
+    tightGap: TIGHT_GAP,
+    quantum: QUANTUM
+});
+
+await browser.close();
+server.close();
+
+// ---------------------------------------------------------------------------
+// Report
+
+const expected = Array.from({ length: HITS }, (_, k) => k * SPACING);
+
+console.log(relative(ROOT, RUNTIME));
+console.log(
+    `${HITS} hits, ${SPACING} frames apart (${(SPACING / QUANTUM).toFixed(3)} blocks), ${SAMPLE_RATE} Hz`
+);
+
+let failed = false;
+for (const [name, onsets] of Object.entries(measured)) {
+    if (onsets.error) {
+        console.log(`  ${name.padEnd(10)} unavailable: ${onsets.error}`);
+        // A runtime with no `time` argument to pass cannot be asked this
+        // question, which is the finding rather than a failure of the harness.
+        if (name !== 'keyOn') failed = true;
+        continue;
+    }
+    const errors = expected.map((frame, i) =>
+        i < onsets.length ? onsets[i] - frame : null
+    );
+    const exact = errors.filter((e) => e === 0).length;
+    const worst = Math.max(
+        0,
+        ...errors.filter((e) => e !== null).map(Math.abs)
+    );
+    console.log(
+        `  ${name.padEnd(10)} ${onsets.length} of ${HITS} sounded, ` +
+            `${exact} on the sample they asked for` +
+            (worst ? `, worst ${worst} frames late` : '')
+    );
+    for (let i = 0; i < expected.length; i++) {
+        if (errors[i] === null)
+            console.log(`             hit ${i} never sounded`);
+        else if (errors[i] !== 0)
+            console.log(`             hit ${i} out by ${errors[i]} frames`);
+    }
+    if (onsets.length !== HITS || exact !== HITS) failed = true;
+}
+
+process.exit(failed ? 1 : 0);
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Everything below runs in the page.
+ *
+ * It is one function because `page.evaluate` serialises it: nothing outside
+ * its own body is in scope there, config included, which is why that arrives
+ * as an argument.
+ */
+async function measure({
+    sampleRate,
+    spacing,
+    hits,
+    gateWidth,
+    tightGap,
+    quantum
+}) {
+    const runtime = await import('/faustwasm.js');
+    const length = (hits + 1) * spacing;
+
+    const load = async (name) => {
+        const [wasm, json] = await Promise.all([
+            fetch(`/${name}.wasm`).then((r) => r.arrayBuffer()),
+            fetch(`/${name}.json`).then((r) => r.text())
+        ]);
+        return {
+            cfactory: 0,
+            code: new Uint8Array(wasm),
+            module: await WebAssembly.compile(wasm),
+            json,
+            poly: false,
+            shaKey: name
+        };
+    };
+
+    /**
+     * The frames where the rendered gate went up.
+     *
+     * The render starts from silence, so frame 0 counts as an edge if the gate
+     * is already up there -- a hit scheduled on the first sample is the one
+     * alignment every implementation gets right, and leaving it out would hide
+     * the off-by-one it produces in everything after it.
+     */
+    const risingEdges = (buffer) => {
+        const data = buffer.getChannelData(0);
+        const edges = [];
+        let previous = 0;
+        for (let i = 0; i < data.length; i++) {
+            if (data[i] > 0.5 && previous <= 0.5) edges.push(i);
+            previous = data[i];
+        }
+        return edges;
+    };
+
+    const context = () =>
+        new OfflineAudioContext({ numberOfChannels: 1, length, sampleRate });
+
+    const monoFactory = await load('probe');
+
+    /** Schedule the gate as an AudioParam, the way a mono voice is played. */
+    const renderMono = async (gap) => {
+        const ctx = context();
+        const generator = new runtime.FaustMonoDspGenerator();
+        generator.name = 'probe';
+        const node = await generator.createNode(ctx, 'probe', {
+            ...monoFactory,
+            // A fresh key per render, or the second one reuses the worklet
+            // processor the first one registered and its AudioParams with it.
+            shaKey: `probe-${gap}`
+        });
+        node.connect(ctx.destination);
+        const gate = node.parameters.get('/Probe/gate');
+        for (let k = 0; k < hits; k++) {
+            const on = k * spacing;
+            gate.setValueAtTime(1, on / sampleRate);
+            gate.setValueAtTime(
+                0,
+                (on + Math.min(gap, spacing - 1)) / sampleRate
+            );
+        }
+        return risingEdges(await ctx.startRendering());
+    };
+
+    const results = {};
+
+    try {
+        results.onsets = await renderMono(gateWidth);
+    } catch (e) {
+        results.onsets = { error: String(e.message || e) };
+    }
+
+    try {
+        results.retrigger = await renderMono(spacing - tightGap);
+    } catch (e) {
+        results.retrigger = { error: String(e.message || e) };
+    }
+
+    // A polyphonic voice takes its trigger by message rather than as an
+    // AudioParam -- `gate` is one of the paths the poly wrapper reserves -- so
+    // this is the half of the question `setValueAtTime` cannot ask.
+    try {
+        const polyFactory = await load('probe-poly');
+        const mixer = await WebAssembly.compile(
+            await fetch('/mixer32.wasm').then((r) => r.arrayBuffer())
+        );
+        const ctx = context();
+        const generator = new runtime.FaustPolyDspGenerator();
+        generator.name = 'probe-poly';
+        const node = await generator.createNode(
+            ctx,
+            16,
+            'probe-poly',
+            polyFactory,
+            mixer
+        );
+        node.connect(ctx.destination);
+        if (node.keyOn.length < 4) {
+            throw new Error('keyOn takes no time argument');
+        }
+        for (let k = 0; k < hits; k++) {
+            const on = k * spacing;
+            node.keyOn(0, 60, 100, on / sampleRate);
+            node.keyOff(0, 60, 0, (on + gateWidth) / sampleRate);
+        }
+        // The messages have to be across the port before rendering starts:
+        // OfflineAudioContext renders as fast as it can and does not wait for
+        // one.
+        await new Promise((resolve) => setTimeout(resolve, 100 + quantum));
+        results.keyOn = risingEdges(await ctx.startRendering());
+    } catch (e) {
+        results.keyOn = { error: String(e.message || e) };
+    }
+
+    return results;
+}
+
+function fail(message) {
+    console.error(message);
+    process.exit(1);
+}

--- a/test/unit/harness.mjs
+++ b/test/unit/harness.mjs
@@ -3,10 +3,9 @@
  *
  * `getFaustAudioWorkletProcessor` reads `AudioWorkletProcessor`,
  * `registerProcessor`, `sampleRate` and `currentFrame` off the global scope,
- * and nothing else about the browser reaches the code these tests are about:
- * the event queue, the automation walk and the block slicing are arithmetic.
- * So they run in plain Node against a fake scope and a fake DSP, and a failure
- * points at a line rather than at a browser.
+ * and needs nothing else from the browser. The event queue, the automation
+ * walk and the block slicing are arithmetic, so they run here in plain Node
+ * against a fake scope and a fake DSP.
  */
 import {
     FaustBaseWebAudioDsp,
@@ -37,12 +36,12 @@ export class FakePort {
 }
 
 /**
- * A DSP that records rather than computes.
+ * A DSP that records instead of computing.
  *
- * It extends the real base class and renders through the real `renderBlock`,
- * with a `render` that only writes down the slice it was asked for. So a test
- * of the processor is also a test that the events it produced tile the block,
- * and the writes below are the ones the slicing loop actually performed.
+ * It extends the real base class and goes through the real `renderBlock`, with
+ * a `render` that just notes the slice it was given. So a processor test also
+ * checks that the events it produced tile the block, and the writes below are
+ * the ones the slicing loop really performed.
  */
 export class FakeDsp extends FaustBaseWebAudioDsp {
     constructor() {
@@ -90,7 +89,7 @@ export class FakeDsp extends FaustBaseWebAudioDsp {
     destroy() {}
 }
 
-/** No accelerometer, no gyroscope, nothing to report. */
+/** Reports no accelerometer or gyroscope data, ever. */
 class SilentCommunicator {
     getNewAccDataAvailable() {
         return false;
@@ -105,8 +104,8 @@ class SilentCommunicator {
 /**
  * The controls the fake DSP declares.
  *
- * A button and a slider is enough: `parameterDescriptors` turns both into
- * AudioParams, and the automation walk does not care which is which.
+ * A button and a slider are enough: `parameterDescriptors` turns both into
+ * AudioParams, and the automation walk treats them alike.
  */
 const DSP_META = {
     name: 'probe',
@@ -129,10 +128,10 @@ const DSP_META = {
 };
 
 /**
- * A monophonic processor on a fake scope, with the clock in the caller's hand.
+ * A monophonic processor on the fake scope, with the clock under test control.
  *
- * `render` advances `currentFrame` by a block, the way the browser does
- * between calls, so a test schedules against the same clock a host would.
+ * `render` advances `currentFrame` by a block, as the browser does between
+ * calls, so tests schedule against the same clock a host would.
  */
 export function monoProcessor({ meta = DSP_META } = {}) {
     const port = new FakePort();
@@ -154,8 +153,8 @@ export function monoProcessor({ meta = DSP_META } = {}) {
 
     const Processor = getFaustAudioWorkletProcessor(
         {
-            // `parameterDescriptors` needs the real UI walk; nothing else of
-            // the base class is reachable from a processor built on a fake DSP.
+            // `parameterDescriptors` needs the real UI walk. Nothing else of
+            // the base class is reachable from a processor on a fake DSP.
             FaustBaseWebAudioDsp,
             FaustMonoWebAudioDsp: function () {
                 return dsp;
@@ -192,9 +191,9 @@ export function monoProcessor({ meta = DSP_META } = {}) {
         /** Seconds, on the clock a host schedules an AudioParam against. */
         time: (f) => f / SAMPLE_RATE,
         /**
-         * One block. `automation` maps a control path to either a single value
-         * the block holds, or the 128 values the browser hands over when it
-         * moves inside the block.
+         * Render one block. `automation` maps a control path to either the
+         * single value the block holds, or the 128 values the browser sends
+         * when the control moves inside the block.
          */
         render(automation = {}) {
             const block = { ...parameters };

--- a/test/unit/harness.mjs
+++ b/test/unit/harness.mjs
@@ -133,7 +133,7 @@ const DSP_META = {
  * `render` advances `currentFrame` by a block, as the browser does between
  * calls, so tests schedule against the same clock a host would.
  */
-export function monoProcessor({ meta = DSP_META } = {}) {
+export function monoProcessor({ meta = DSP_META, wamInfo = false } = {}) {
     const port = new FakePort();
     const dsp = new FakeDsp();
     let frame = 0;
@@ -172,7 +172,14 @@ export function monoProcessor({ meta = DSP_META } = {}) {
     );
 
     const processor = new Processor({
-        processorOptions: { name: 'probe', sampleSize: 4, factory: {} }
+        processorOptions: {
+            name: 'probe',
+            sampleSize: 4,
+            factory: {},
+            // Only a processor told which WAM instance it belongs to will look
+            // for a param manager at all.
+            ...(wamInfo ? { moduleId: 'module', instanceId: 'instance' } : {})
+        }
     });
 
     const parameters = {};
@@ -180,10 +187,23 @@ export function monoProcessor({ meta = DSP_META } = {}) {
         parameters[name] = new Float32Array([defaultValue]);
     }
 
+    /**
+     * A WAM param manager for this processor to find.
+     *
+     * `setupWamEventHandler` looks the processor up through the global
+     * `webAudioModules` registry and installs itself as the handler, so a test
+     * of that path has to put a registry there first.
+     */
+    const wam = { handleEvent: null };
+    scope.webAudioModules = {
+        getModuleScope: () => ({ paramMgrProcessors: { instance: wam } })
+    };
+
     return {
         dsp,
         port,
         processor,
+        wam,
         /** The frame the next `render` will start at. */
         get frame() {
             return frame;

--- a/test/unit/harness.mjs
+++ b/test/unit/harness.mjs
@@ -1,0 +1,212 @@
+/**
+ * An AudioWorkletGlobalScope made of ordinary objects.
+ *
+ * `getFaustAudioWorkletProcessor` reads `AudioWorkletProcessor`,
+ * `registerProcessor`, `sampleRate` and `currentFrame` off the global scope,
+ * and nothing else about the browser reaches the code these tests are about:
+ * the event queue, the automation walk and the block slicing are arithmetic.
+ * So they run in plain Node against a fake scope and a fake DSP, and a failure
+ * points at a line rather than at a browser.
+ */
+import {
+    FaustBaseWebAudioDsp,
+    getFaustAudioWorkletProcessor
+} from '../../dist/esm/index.js';
+
+export const SAMPLE_RATE = 48000;
+export const BLOCK = 128;
+
+/** A MessagePort that hands messages straight to whoever is listening. */
+export class FakePort {
+    constructor() {
+        this.posted = [];
+        this.listeners = [];
+    }
+    addEventListener(type, fn) {
+        if (type === 'message') this.listeners.push(fn);
+    }
+    start() {}
+    close() {}
+    postMessage(data) {
+        this.posted.push(data);
+    }
+    /** Deliver a message as if it had arrived from the main thread. */
+    send(data) {
+        for (const fn of this.listeners) fn({ data });
+    }
+}
+
+/**
+ * A DSP that records rather than computes.
+ *
+ * It extends the real base class and renders through the real `renderBlock`,
+ * with a `render` that only writes down the slice it was asked for. So a test
+ * of the processor is also a test that the events it produced tile the block,
+ * and the writes below are the ones the slicing loop actually performed.
+ */
+export class FakeDsp extends FaustBaseWebAudioDsp {
+    constructor() {
+        super(4, BLOCK, {});
+        this.blocks = [];
+        this.slices = [];
+        this.writes = [];
+        this.notes = [];
+        this.midi = [];
+    }
+    compute(inputs, outputs, events) {
+        this.blocks.push(
+            (events || []).map((e) => ({ frame: e.frame, seq: e.seq }))
+        );
+        const parts = [];
+        this.renderBlock(events, (offset, count) =>
+            parts.push([offset, count])
+        );
+        this.slices.push(parts);
+        return true;
+    }
+    setParamValue(path, value) {
+        this.writes.push({ path, value });
+    }
+    keyOn(channel, pitch, velocity) {
+        this.notes.push({ type: 'keyOn', channel, pitch, velocity });
+    }
+    keyOff(channel, pitch, velocity) {
+        this.notes.push({ type: 'keyOff', channel, pitch, velocity });
+    }
+    ctrlChange(channel, ctrl, value) {
+        this.midi.push({ type: 'ctrlChange', channel, ctrl, value });
+    }
+    pitchWheel(channel, wheel) {
+        this.midi.push({ type: 'pitchWheel', channel, wheel });
+    }
+    midiMessage(data) {
+        this.midi.push({ type: 'midi', data: [...data] });
+    }
+    start() {}
+    stop() {}
+    setOutputParamHandler() {}
+    setInputParamHandler() {}
+    setPlotHandler() {}
+    destroy() {}
+}
+
+/** No accelerometer, no gyroscope, nothing to report. */
+class SilentCommunicator {
+    getNewAccDataAvailable() {
+        return false;
+    }
+    getNewGyrDataAvailable() {
+        return false;
+    }
+    setNewAccDataAvailable() {}
+    setNewGyrDataAvailable() {}
+}
+
+/**
+ * The controls the fake DSP declares.
+ *
+ * A button and a slider is enough: `parameterDescriptors` turns both into
+ * AudioParams, and the automation walk does not care which is which.
+ */
+const DSP_META = {
+    name: 'probe',
+    ui: [
+        {
+            type: 'vgroup',
+            label: 'probe',
+            items: [
+                { type: 'button', address: '/probe/gate', init: 0 },
+                {
+                    type: 'hslider',
+                    address: '/probe/vol',
+                    init: 0.5,
+                    min: 0,
+                    max: 1
+                }
+            ]
+        }
+    ]
+};
+
+/**
+ * A monophonic processor on a fake scope, with the clock in the caller's hand.
+ *
+ * `render` advances `currentFrame` by a block, the way the browser does
+ * between calls, so a test schedules against the same clock a host would.
+ */
+export function monoProcessor({ meta = DSP_META } = {}) {
+    const port = new FakePort();
+    const dsp = new FakeDsp();
+    let frame = 0;
+
+    const scope = globalThis;
+    scope.sampleRate = SAMPLE_RATE;
+    scope.registerProcessor = () => {};
+    scope.AudioWorkletProcessor = class {
+        constructor() {
+            this.port = port;
+        }
+    };
+    Object.defineProperty(scope, 'currentFrame', {
+        configurable: true,
+        get: () => frame
+    });
+
+    const Processor = getFaustAudioWorkletProcessor(
+        {
+            // `parameterDescriptors` needs the real UI walk; nothing else of
+            // the base class is reachable from a processor built on a fake DSP.
+            FaustBaseWebAudioDsp,
+            FaustMonoWebAudioDsp: function () {
+                return dsp;
+            },
+            FaustWasmInstantiator: { createSyncMonoDSPInstance: () => ({}) },
+            FaustAudioWorkletProcessorCommunicator: SilentCommunicator
+        },
+        {
+            processorName: 'probe',
+            dspName: 'probe',
+            dspMeta: meta,
+            poly: false
+        },
+        false
+    );
+
+    const processor = new Processor({
+        processorOptions: { name: 'probe', sampleSize: 4, factory: {} }
+    });
+
+    const parameters = {};
+    for (const { name, defaultValue } of Processor.parameterDescriptors) {
+        parameters[name] = new Float32Array([defaultValue]);
+    }
+
+    return {
+        dsp,
+        port,
+        processor,
+        /** The frame the next `render` will start at. */
+        get frame() {
+            return frame;
+        },
+        /** Seconds, on the clock a host schedules an AudioParam against. */
+        time: (f) => f / SAMPLE_RATE,
+        /**
+         * One block. `automation` maps a control path to either a single value
+         * the block holds, or the 128 values the browser hands over when it
+         * moves inside the block.
+         */
+        render(automation = {}) {
+            const block = { ...parameters };
+            for (const [path, value] of Object.entries(automation)) {
+                block[path] = Array.isArray(value)
+                    ? new Float32Array(value)
+                    : new Float32Array([value]);
+                parameters[path] = block[path].slice(-1);
+            }
+            processor.process([[]], [[]], block);
+            frame += BLOCK;
+            return dsp.blocks[dsp.blocks.length - 1];
+        }
+    };
+}

--- a/test/unit/node-api.test.mjs
+++ b/test/unit/node-api.test.mjs
@@ -1,10 +1,9 @@
 /**
  * What the node puts on the wire.
  *
- * The node's side of this is small -- a `time` argument carried through to the
- * message -- but it is the half a host actually calls, and a dropped field
- * turns a sample-accurate schedule back into "whenever the message lands"
- * without any error to notice.
+ * The node's side is small -- a `time` argument carried into the message --
+ * but it is the half a host calls, and dropping the field silently turns a
+ * sample-accurate schedule back into "whenever the message lands".
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -45,8 +44,8 @@ class FakePort {
 
 /**
  * `FaustAudioWorkletNode` extends `globalThis.AudioWorkletNode`, which is read
- * when the module is evaluated -- so the stand-in has to be in place before the
- * import, and the import has to be dynamic for that to be possible.
+ * when the module is evaluated. So the stand-in has to exist before the
+ * import, which means the import has to be dynamic.
  */
 globalThis.AudioWorkletNode = class {
     constructor(context) {
@@ -131,7 +130,7 @@ test('midiMessage passes its time down to the note it decodes', () => {
 
 test('a MIDI message with no typed form keeps its time', () => {
     const node = monoNode();
-    // Program change: nothing else handles it, so it goes over as raw bytes.
+    // Program change: nothing else handles it, so it crosses as raw bytes.
     const [message] = posted(node, () => node.midiMessage([0xc0, 5, 0], 9.5));
     assert.equal(message.type, 'midi');
     assert.equal(message.time, 9.5);
@@ -171,7 +170,7 @@ test('a rejected time leaves nothing on the wire', () => {
     node.parameters.set('/probe/gate', {
         value: 0,
         setValueAtTime: (value, time) => {
-            // What a real AudioParam does with a negative time.
+            // What a real AudioParam does with a negative time
             if (!(time >= 0)) throw new RangeError('time must be non-negative');
         }
     });

--- a/test/unit/node-api.test.mjs
+++ b/test/unit/node-api.test.mjs
@@ -165,3 +165,21 @@ test('setParamValue without a time still schedules at the context clock', () => 
     node.setParamValue('/probe/gate', 1);
     assert.deepEqual(scheduled, [{ value: 1, time: context.currentTime }]);
 });
+
+test('a rejected time leaves nothing on the wire', () => {
+    const node = monoNode();
+    node.parameters.set('/probe/gate', {
+        value: 0,
+        setValueAtTime: (value, time) => {
+            // What a real AudioParam does with a negative time.
+            if (!(time >= 0)) throw new RangeError('time must be non-negative');
+        }
+    });
+    node.port.posted.length = 0;
+    assert.throws(() => node.setParamValue('/probe/gate', 1, -1), RangeError);
+    assert.deepEqual(
+        node.port.posted,
+        [],
+        'or the DSP holds a value the AudioParam refused'
+    );
+});

--- a/test/unit/node-api.test.mjs
+++ b/test/unit/node-api.test.mjs
@@ -1,0 +1,167 @@
+/**
+ * What the node puts on the wire.
+ *
+ * The node's side of this is small -- a `time` argument carried through to the
+ * message -- but it is the half a host actually calls, and a dropped field
+ * turns a sample-accurate schedule back into "whenever the message lands"
+ * without any error to notice.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const JSON_DSP = JSON.stringify({
+    name: 'probe',
+    inputs: 0,
+    outputs: 1,
+    ui: [
+        {
+            type: 'vgroup',
+            label: 'probe',
+            items: [
+                {
+                    type: 'button',
+                    address: '/probe/gate',
+                    label: 'gate',
+                    shortname: 'gate',
+                    init: 0
+                }
+            ]
+        }
+    ]
+});
+
+/** A MessagePort that keeps what was posted to it. */
+class FakePort {
+    constructor() {
+        this.posted = [];
+    }
+    addEventListener() {}
+    start() {}
+    close() {}
+    postMessage(data) {
+        this.posted.push(data);
+    }
+}
+
+/**
+ * `FaustAudioWorkletNode` extends `globalThis.AudioWorkletNode`, which is read
+ * when the module is evaluated -- so the stand-in has to be in place before the
+ * import, and the import has to be dynamic for that to be possible.
+ */
+globalThis.AudioWorkletNode = class {
+    constructor(context) {
+        this.context = context;
+        this.port = new FakePort();
+        this.parameters = new Map();
+    }
+};
+
+const { FaustMonoAudioWorkletNode, FaustPolyAudioWorkletNode } =
+    await import('../../dist/esm/index.js');
+
+const context = { sampleRate: 48000, currentTime: 1.5 };
+
+function monoNode() {
+    return new FaustMonoAudioWorkletNode(context, {
+        processorOptions: {
+            name: 'probe',
+            sampleSize: 4,
+            factory: { json: JSON_DSP }
+        }
+    });
+}
+
+function polyNode() {
+    return new FaustPolyAudioWorkletNode(context, {
+        processorOptions: {
+            name: 'probe',
+            sampleSize: 4,
+            voices: 8,
+            voiceFactory: { json: JSON_DSP },
+            mixerModule: {}
+        }
+    });
+}
+
+/** The messages a call posted, ignoring anything the constructor sent. */
+function posted(node, run) {
+    node.port.posted.length = 0;
+    run();
+    return node.port.posted;
+}
+
+test('keyOn carries the time it was given', () => {
+    const node = monoNode();
+    const [message] = posted(node, () => node.keyOn(0, 60, 100, 2.25));
+    assert.deepEqual(message, {
+        type: 'keyOn',
+        data: [0, 60, 100],
+        time: 2.25
+    });
+});
+
+test('keyOn without a time carries none', () => {
+    const node = monoNode();
+    const [message] = posted(node, () => node.keyOn(0, 60, 100));
+    assert.equal(message.type, 'keyOn');
+    assert.equal(message.time, undefined);
+});
+
+test('keyOff, ctrlChange and pitchWheel carry a time too', () => {
+    const node = monoNode();
+    assert.equal(posted(node, () => node.keyOff(0, 60, 0, 3))[0].time, 3);
+    assert.equal(posted(node, () => node.ctrlChange(0, 7, 64, 4))[0].time, 4);
+    assert.equal(posted(node, () => node.pitchWheel(0, 8192, 5))[0].time, 5);
+});
+
+test('a polyphonic node carries a time on keyOn and keyOff', () => {
+    const node = polyNode();
+    assert.equal(posted(node, () => node.keyOn(0, 60, 100, 6))[0].time, 6);
+    assert.equal(posted(node, () => node.keyOff(0, 60, 0, 7))[0].time, 7);
+});
+
+test('midiMessage passes its time down to the note it decodes', () => {
+    const node = monoNode();
+    const [message] = posted(node, () =>
+        node.midiMessage([0x90, 60, 100], 8.5)
+    );
+    assert.equal(message.type, 'keyOn');
+    assert.equal(message.time, 8.5);
+});
+
+test('a MIDI message with no typed form keeps its time', () => {
+    const node = monoNode();
+    // Program change: nothing else handles it, so it goes over as raw bytes.
+    const [message] = posted(node, () => node.midiMessage([0xc0, 5, 0], 9.5));
+    assert.equal(message.type, 'midi');
+    assert.equal(message.time, 9.5);
+});
+
+test('setParamValue carries the time, and schedules the AudioParam for it', () => {
+    const node = monoNode();
+    const scheduled = [];
+    node.parameters.set('/probe/gate', {
+        value: 0,
+        setValueAtTime: (value, time) => scheduled.push({ value, time })
+    });
+    const [message] = posted(node, () =>
+        node.setParamValue('/probe/gate', 1, 10.25)
+    );
+    assert.deepEqual(message, {
+        type: 'param',
+        data: { path: '/probe/gate', value: 1 },
+        time: 10.25
+    });
+    assert.deepEqual(scheduled, [{ value: 1, time: 10.25 }]);
+});
+
+test('setParamValue without a time still schedules at the context clock', () => {
+    const node = monoNode();
+    const scheduled = [];
+    node.parameters.set('/probe/gate', {
+        value: 0,
+        setValueAtTime: (value, time) => scheduled.push({ value, time })
+    });
+    node.setParamValue('/probe/gate', 1);
+    assert.deepEqual(scheduled, [{ value: 1, time: context.currentTime }]);
+});

--- a/test/unit/render-block.test.mjs
+++ b/test/unit/render-block.test.mjs
@@ -9,7 +9,11 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { FaustBaseWebAudioDsp } from '../../dist/esm/index.js';
+import {
+    FaustBaseWebAudioDsp,
+    FaustMonoWebAudioDsp,
+    FaustPolyWebAudioDsp
+} from '../../dist/esm/index.js';
 
 const BLOCK = 128;
 
@@ -137,3 +141,59 @@ test('a negative frame is applied at the top of the block', () => {
         'render:0+128'
     ]);
 });
+
+test('applyEvents performs everything, in order, without rendering', () => {
+    const log = [];
+    const events = ['a', 'b', 'c'].map((name, i) => ({
+        frame: i * 10,
+        apply: () => log.push(name)
+    }));
+    dsp().applyEvents(events);
+    assert.deepEqual(log, ['a', 'b', 'c']);
+    assert.doesNotThrow(() => dsp().applyEvents(undefined));
+});
+
+/**
+ * A block the DSP declines to render still has to take its control writes.
+ *
+ * They have already been taken off the processor's queue by the time `compute`
+ * sees them, so a `keyOn` dropped here is a note that never sounds and never
+ * will -- and the DSP's cached values would go on disagreeing with the host's.
+ * The receiver is a bare base DSP, which is all these branches touch --
+ * `fFirstCall` aside, since the polyphonic `compute` lays out its wasm memory
+ * before it asks whether it is running.
+ */
+for (const [name, compute] of [
+    ['mono', FaustMonoWebAudioDsp.prototype.compute],
+    ['poly', FaustPolyWebAudioDsp.prototype.compute]
+]) {
+    test(`a stopped ${name} DSP still applies the block's events`, () => {
+        const log = [];
+        const stopped = dsp();
+        stopped.fFirstCall = false;
+        stopped.stop();
+        const result = compute.call(
+            stopped,
+            [],
+            [],
+            [{ frame: 0, apply: () => log.push('applied') }]
+        );
+        assert.equal(result, true, 'and stays in the graph');
+        assert.deepEqual(log, ['applied']);
+    });
+
+    test(`a destroyed ${name} DSP drops them`, () => {
+        const log = [];
+        const destroyed = dsp();
+        destroyed.fFirstCall = false;
+        destroyed.destroy();
+        const result = compute.call(
+            destroyed,
+            [],
+            [],
+            [{ frame: 0, apply: () => log.push('applied') }]
+        );
+        assert.equal(result, false);
+        assert.deepEqual(log, [], 'which is the point of destroying it');
+    });
+}

--- a/test/unit/render-block.test.mjs
+++ b/test/unit/render-block.test.mjs
@@ -1,0 +1,139 @@
+/**
+ * The block slicing itself.
+ *
+ * `renderBlock` is the whole of what makes a control land on a sample: walk to
+ * the frame of the next event, render what came before it, apply it, carry on.
+ * It touches no wasm, so the arithmetic is checked here against a `render` that
+ * only writes down what it was asked for -- the slices must tile the block
+ * exactly, in order, with the events falling between the right ones.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { FaustBaseWebAudioDsp } from '../../dist/esm/index.js';
+
+const BLOCK = 128;
+
+/**
+ * A DSP that renders nothing.
+ *
+ * `renderBlock` is `protected` in TypeScript and an ordinary method at
+ * runtime; the base class is constructible on its own, and nothing below
+ * reaches past it.
+ */
+function dsp() {
+    return new FaustBaseWebAudioDsp(4, BLOCK, {});
+}
+
+/** Run a block and return what happened, in order. */
+function run(events) {
+    const log = [];
+    const stamped = events.map((e) => ({
+        frame: e.frame,
+        apply: () => log.push(`apply:${e.name}`)
+    }));
+    dsp().renderBlock(stamped, (offset, count) =>
+        log.push(`render:${offset}+${count}`)
+    );
+    return log;
+}
+
+/** The slices, as [offset, count] pairs. */
+function slices(log) {
+    return log
+        .filter((l) => l.startsWith('render:'))
+        .map((l) => l.slice(7).split('+').map(Number));
+}
+
+test('no events renders the block in one call', () => {
+    const log = [];
+    dsp().renderBlock(undefined, (offset, count) =>
+        log.push(`render:${offset}+${count}`)
+    );
+    assert.deepEqual(log, ['render:0+128']);
+});
+
+test('an empty event list renders the block in one call', () => {
+    assert.deepEqual(run([]), ['render:0+128']);
+});
+
+test('an event splits the block at its frame', () => {
+    assert.deepEqual(run([{ frame: 64, name: 'a' }]), [
+        'render:0+64',
+        'apply:a',
+        'render:64+64'
+    ]);
+});
+
+test('an event on frame 0 is applied before anything is rendered', () => {
+    assert.deepEqual(run([{ frame: 0, name: 'a' }]), [
+        'apply:a',
+        'render:0+128'
+    ]);
+});
+
+test('an event on the last frame leaves a one-frame slice after it', () => {
+    assert.deepEqual(run([{ frame: 127, name: 'a' }]), [
+        'render:0+127',
+        'apply:a',
+        'render:127+1'
+    ]);
+});
+
+test('two events on one frame do not produce an empty slice', () => {
+    assert.deepEqual(
+        run([
+            { frame: 40, name: 'a' },
+            { frame: 40, name: 'b' }
+        ]),
+        ['render:0+40', 'apply:a', 'apply:b', 'render:40+88']
+    );
+});
+
+test('events are applied in the order they are given', () => {
+    const log = run([
+        { frame: 10, name: 'a' },
+        { frame: 20, name: 'b' },
+        { frame: 30, name: 'c' }
+    ]);
+    assert.deepEqual(
+        log.filter((l) => l.startsWith('apply:')),
+        ['apply:a', 'apply:b', 'apply:c']
+    );
+});
+
+test('the slices tile the block exactly, however many events there are', () => {
+    for (const frames of [
+        [1],
+        [0, 127],
+        [5, 5, 5],
+        [0, 1, 2, 3, 64, 127],
+        Array.from({ length: BLOCK }, (_, i) => i)
+    ]) {
+        const parts = slices(
+            run(frames.map((frame, i) => ({ frame, name: i })))
+        );
+        let at = 0;
+        for (const [offset, count] of parts) {
+            assert.equal(offset, at, `slice starts where the last one ended`);
+            assert.ok(count > 0, 'no empty slice reaches wasm');
+            at += count;
+        }
+        assert.equal(
+            at,
+            BLOCK,
+            `${frames.length} events still render 128 frames`
+        );
+    }
+});
+
+test('a frame past the end of the block cannot run off it', () => {
+    const parts = slices(run([{ frame: 1000, name: 'a' }]));
+    assert.deepEqual(parts, [[0, 128]]);
+});
+
+test('a negative frame is applied at the top of the block', () => {
+    assert.deepEqual(run([{ frame: -5, name: 'a' }]), [
+        'apply:a',
+        'render:0+128'
+    ]);
+});

--- a/test/unit/render-block.test.mjs
+++ b/test/unit/render-block.test.mjs
@@ -1,11 +1,11 @@
 /**
- * The block slicing itself.
+ * The block slicing.
  *
- * `renderBlock` is the whole of what makes a control land on a sample: walk to
- * the frame of the next event, render what came before it, apply it, carry on.
- * It touches no wasm, so the arithmetic is checked here against a `render` that
- * only writes down what it was asked for -- the slices must tile the block
- * exactly, in order, with the events falling between the right ones.
+ * `renderBlock` is what makes a control land on a sample: render up to the
+ * next event's frame, apply it, carry on. It touches no wasm, so it is checked
+ * here against a `render` that only records what it was asked for. The slices
+ * must tile the block exactly, in order, with each event between the right
+ * two.
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -21,14 +21,14 @@ const BLOCK = 128;
  * A DSP that renders nothing.
  *
  * `renderBlock` is `protected` in TypeScript and an ordinary method at
- * runtime; the base class is constructible on its own, and nothing below
+ * runtime. The base class is constructible on its own, and nothing below
  * reaches past it.
  */
 function dsp() {
     return new FaustBaseWebAudioDsp(4, BLOCK, {});
 }
 
-/** Run a block and return what happened, in order. */
+/** Render a block and return what happened, in order. */
 function run(events) {
     const log = [];
     const stamped = events.map((e) => ({
@@ -154,14 +154,15 @@ test('applyEvents performs everything, in order, without rendering', () => {
 });
 
 /**
- * A block the DSP declines to render still has to take its control writes.
+ * A block the DSP declines to render still has to apply its control writes.
  *
- * They have already been taken off the processor's queue by the time `compute`
- * sees them, so a `keyOn` dropped here is a note that never sounds and never
- * will -- and the DSP's cached values would go on disagreeing with the host's.
- * The receiver is a bare base DSP, which is all these branches touch --
- * `fFirstCall` aside, since the polyphonic `compute` lays out its wasm memory
- * before it asks whether it is running.
+ * By the time `compute` sees them they have already left the processor's
+ * queue, so dropping a `keyOn` here loses it for good, and the DSP's cached
+ * values would disagree with the host's from then on.
+ *
+ * The receiver is a bare base DSP, which is all these branches touch, apart
+ * from `fFirstCall`: the polyphonic `compute` lays out its wasm memory before
+ * checking whether it is running.
  */
 for (const [name, compute] of [
     ['mono', FaustMonoWebAudioDsp.prototype.compute],

--- a/test/unit/render-block.test.mjs
+++ b/test/unit/render-block.test.mjs
@@ -154,11 +154,7 @@ test('applyEvents performs everything, in order, without rendering', () => {
 });
 
 /**
- * A block the DSP declines to render still has to apply its control writes.
- *
- * By the time `compute` sees them they have already left the processor's
- * queue, so dropping a `keyOn` here loses it for good, and the DSP's cached
- * values would disagree with the host's from then on.
+ * A block the DSP declines to render still applies its control writes.
  *
  * The receiver is a bare base DSP, which is all these branches touch, apart
  * from `fFirstCall`: the polyphonic `compute` lays out its wasm memory before

--- a/test/unit/timed-events.test.mjs
+++ b/test/unit/timed-events.test.mjs
@@ -389,3 +389,37 @@ test('only the controllers that silence the instrument flush', () => {
         );
     }
 });
+
+// The WAM path had its own way of losing a note: `setupWamEventHandler`
+// installed a handler that called `midiMessage` directly and dropped the
+// event's time, so anything routed through Web Audio Modules landed at the top
+// of whichever block it was processed in -- the scatter this whole branch
+// exists to remove, still there on the one route that was not a port message.
+test('a WAM MIDI event is applied on the frame it carries', () => {
+    const p = monoProcessor({ wamInfo: true });
+    p.port.send({ type: 'setupWamEventHandler' });
+    assert.equal(
+        typeof p.wam.handleEvent,
+        'function',
+        'the handler is installed'
+    );
+
+    p.wam.handleEvent({
+        type: 'wam-midi',
+        // WamEvent.time is AudioContext seconds, the same clock as a port
+        // message's, so it belongs in the same queue.
+        time: 55 / SAMPLE_RATE,
+        data: { bytes: [144, 60, 100] }
+    });
+    assert.deepEqual(p.dsp.midi, [], 'not applied on arrival');
+    assert.deepEqual(frames(p.render()), [55]);
+    assert.deepEqual(p.dsp.midi, [{ type: 'midi', data: [144, 60, 100] }]);
+});
+
+test('a WAM MIDI event with no time is applied on arrival', () => {
+    const p = monoProcessor({ wamInfo: true });
+    p.port.send({ type: 'setupWamEventHandler' });
+    p.wam.handleEvent({ type: 'wam-midi', data: { bytes: [144, 60, 100] } });
+    assert.deepEqual(p.dsp.midi, [{ type: 'midi', data: [144, 60, 100] }]);
+    assert.deepEqual(p.render(), []);
+});

--- a/test/unit/timed-events.test.mjs
+++ b/test/unit/timed-events.test.mjs
@@ -1,0 +1,240 @@
+/**
+ * What the processor hands `compute` for a block.
+ *
+ * Two sources meet in `collectEvents`: the automation an `AudioParam` hands
+ * `process` for the block, and the port messages that were timestamped for a
+ * frame inside it. These tests are about the frames -- that a step at 40 is an
+ * event at 40 and not at 0, that a `1 -> 0 -> 1` inside one block is two edges
+ * and not none, that a message for a later block waits for it.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { monoProcessor, BLOCK, SAMPLE_RATE } from './harness.mjs';
+
+const GATE = '/probe/gate';
+const VOL = '/probe/vol';
+
+/** A block of automation: `value` from `at` onwards, `from` before it. */
+function step(from, value, at) {
+    return Array.from({ length: BLOCK }, (_, i) => (i < at ? from : value));
+}
+
+test('a block where nothing moves carries no events', () => {
+    const p = monoProcessor();
+    assert.deepEqual(p.render(), []);
+    assert.deepEqual(p.dsp.writes, []);
+});
+
+test('a control that changes between blocks is written once, at frame 0', () => {
+    const p = monoProcessor();
+    p.render();
+    assert.deepEqual(p.render({ [VOL]: 0.25 }), [{ frame: 0, seq: -1 }]);
+    assert.deepEqual(p.dsp.writes, [{ path: VOL, value: 0.25 }]);
+});
+
+test('a control that holds its new value is not written again', () => {
+    const p = monoProcessor();
+    p.render({ [VOL]: 0.25 });
+    p.render({ [VOL]: 0.25 });
+    p.render();
+    assert.equal(p.dsp.writes.length, 1);
+});
+
+test('a step inside the block is an event on the frame it happens', () => {
+    const p = monoProcessor();
+    const events = p.render({ [GATE]: step(0, 1, 40) });
+    assert.deepEqual(events, [{ frame: 40, seq: -1 }]);
+    assert.deepEqual(p.dsp.writes, [{ path: GATE, value: 1 }]);
+});
+
+test('1 -> 0 -> 1 inside one block is two edges, not none', () => {
+    const p = monoProcessor();
+    // The gate is already up when the block starts, drops at 60 and comes back
+    // at 70. Reading only frame 0 sees 1, compares it to a cached 1, and lets
+    // the whole thing through unnoticed: the hit that never retriggers.
+    p.render({ [GATE]: 1 });
+    const automation = Array.from({ length: BLOCK }, (_, i) =>
+        i >= 60 && i < 70 ? 0 : 1
+    );
+    assert.deepEqual(p.render({ [GATE]: automation }), [
+        { frame: 60, seq: -1 },
+        { frame: 70, seq: -1 }
+    ]);
+    assert.deepEqual(p.dsp.writes.slice(1), [
+        { path: GATE, value: 0 },
+        { path: GATE, value: 1 }
+    ]);
+});
+
+test('every step of a ramp is its own event', () => {
+    const p = monoProcessor();
+    const events = p.render({
+        [VOL]: Array.from({ length: BLOCK }, (_, i) => i / BLOCK)
+    });
+    assert.equal(events.length, BLOCK);
+    assert.deepEqual(
+        events.map((e) => e.frame),
+        Array.from({ length: BLOCK }, (_, i) => i)
+    );
+    assert.deepEqual(
+        p.dsp.writes.map((w) => w.value),
+        Array.from({ length: BLOCK }, (_, i) => i / BLOCK)
+    );
+});
+
+test('a ramp that starts where the control already is skips frame 0', () => {
+    const p = monoProcessor();
+    // 0.5 is the control's `init`, which is what the cache was seeded with.
+    const events = p.render({
+        [VOL]: Array.from({ length: BLOCK }, (_, i) => 0.5 + i / 256)
+    });
+    assert.equal(events.length, BLOCK - 1);
+    assert.equal(events[0].frame, 1);
+    assert.equal(events.at(-1).frame, BLOCK - 1);
+});
+
+test('an untimed message is applied on arrival, before the next block', () => {
+    const p = monoProcessor();
+    p.port.send({ type: 'keyOn', data: [0, 60, 100] });
+    assert.deepEqual(p.dsp.notes, [
+        { type: 'keyOn', channel: 0, pitch: 60, velocity: 100 }
+    ]);
+    assert.deepEqual(p.render(), []);
+});
+
+test('a timed message waits for its frame inside the right block', () => {
+    const p = monoProcessor();
+    p.port.send({ type: 'keyOn', data: [0, 60, 100], time: 40 / SAMPLE_RATE });
+    assert.deepEqual(p.dsp.notes, [], 'not applied on arrival');
+    const events = p.render();
+    assert.equal(events.length, 1);
+    assert.equal(events[0].frame, 40);
+    assert.deepEqual(p.dsp.notes, [
+        { type: 'keyOn', channel: 0, pitch: 60, velocity: 100 }
+    ]);
+});
+
+test('a message for a later block is held until that block', () => {
+    const p = monoProcessor();
+    // Three blocks out, 20 frames in.
+    const frame = 3 * BLOCK + 20;
+    p.port.send({
+        type: 'keyOn',
+        data: [0, 60, 100],
+        time: frame / SAMPLE_RATE
+    });
+    assert.deepEqual(p.render(), []);
+    assert.deepEqual(p.render(), []);
+    assert.deepEqual(p.render(), []);
+    const events = p.render();
+    assert.equal(events.length, 1);
+    assert.equal(events[0].frame, 20, 'offset from the start of its own block');
+});
+
+test('a message whose block has gone by happens at the top of this one', () => {
+    const p = monoProcessor();
+    p.render();
+    p.render();
+    p.port.send({ type: 'keyOn', data: [0, 60, 100], time: 10 / SAMPLE_RATE });
+    const events = p.render();
+    assert.equal(events.length, 1);
+    assert.equal(events[0].frame, 0, 'late, not lost');
+});
+
+test('a frame is taken as given, alongside a time in seconds', () => {
+    const p = monoProcessor();
+    p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 77 });
+    assert.equal(p.render()[0].frame, 77);
+});
+
+test('a timed param message is written at its frame', () => {
+    const p = monoProcessor();
+    p.port.send({
+        type: 'param',
+        data: { path: VOL, value: 0.75 },
+        time: 33 / SAMPLE_RATE
+    });
+    assert.deepEqual(p.dsp.writes, [], 'not applied on arrival');
+    assert.equal(p.render()[0].frame, 33);
+    assert.deepEqual(p.dsp.writes, [{ path: VOL, value: 0.75 }]);
+});
+
+test('a timed MIDI message reaches the DSP at its frame', () => {
+    const p = monoProcessor();
+    p.port.send({ type: 'midi', data: [144, 60, 100], time: 12 / SAMPLE_RATE });
+    assert.deepEqual(p.dsp.midi, []);
+    assert.equal(p.render()[0].frame, 12);
+    assert.deepEqual(p.dsp.midi, [{ type: 'midi', data: [144, 60, 100] }]);
+});
+
+test('messages on one frame keep the order they were posted', () => {
+    const p = monoProcessor();
+    const time = 50 / SAMPLE_RATE;
+    p.port.send({ type: 'keyOff', data: [0, 60, 0], time });
+    p.port.send({ type: 'keyOn', data: [0, 60, 100], time });
+    p.render();
+    assert.deepEqual(
+        p.dsp.notes.map((n) => n.type),
+        ['keyOff', 'keyOn'],
+        'a keyOn sorted ahead of the keyOff before it would leave a voice on'
+    );
+});
+
+test('messages posted out of order are applied in time order', () => {
+    const p = monoProcessor();
+    p.port.send({ type: 'keyOn', data: [0, 62, 100], time: 90 / SAMPLE_RATE });
+    p.port.send({ type: 'keyOn', data: [0, 60, 100], time: 10 / SAMPLE_RATE });
+    const events = p.render();
+    assert.deepEqual(
+        events.map((e) => e.frame),
+        [10, 90]
+    );
+    assert.deepEqual(
+        p.dsp.notes.map((n) => n.pitch),
+        [60, 62]
+    );
+});
+
+test('automation goes before a message on the same frame', () => {
+    const p = monoProcessor();
+    p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 40 });
+    const events = p.render({ [GATE]: step(0, 1, 40) });
+    assert.deepEqual(
+        events.map((e) => e.frame),
+        [40, 40]
+    );
+    assert.equal(events[0].seq, -1, 'the block starts from the automation');
+    assert.ok(events[1].seq >= 0);
+});
+
+test('the events of a block always tile it exactly', () => {
+    const p = monoProcessor();
+    p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 0 });
+    p.port.send({ type: 'keyOn', data: [0, 62, 100], frame: 60 });
+    p.port.send({ type: 'keyOff', data: [0, 60, 0], frame: 60 });
+    p.port.send({ type: 'keyOff', data: [0, 62, 0], frame: BLOCK - 1 });
+    p.render({ [GATE]: step(0, 1, 60) });
+    // The fake DSP renders through the real `renderBlock`, so this is what the
+    // wasm calls would have been.
+    const parts = p.dsp.slices[0];
+    assert.deepEqual(parts, [
+        [0, 60],
+        [60, 67],
+        [127, 1]
+    ]);
+    assert.equal(
+        parts.reduce((n, [, count]) => n + count, 0),
+        BLOCK
+    );
+});
+
+test('automation and messages interleave by frame', () => {
+    const p = monoProcessor();
+    p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 20 });
+    p.port.send({ type: 'keyOn', data: [0, 62, 100], frame: 100 });
+    const events = p.render({ [GATE]: step(0, 1, 60) });
+    assert.deepEqual(
+        events.map((e) => e.frame),
+        [20, 60, 100]
+    );
+});

--- a/test/unit/timed-events.test.mjs
+++ b/test/unit/timed-events.test.mjs
@@ -1,11 +1,11 @@
 /**
  * What the processor hands `compute` for a block.
  *
- * Two sources meet in `collectEvents`: the automation an `AudioParam` hands
- * `process` for the block, and the port messages that were timestamped for a
- * frame inside it. These tests are about the frames -- that a step at 40 is an
- * event at 40 and not at 0, that a `1 -> 0 -> 1` inside one block is two edges
- * and not none, that a message for a later block waits for it.
+ * `collectEvents` merges two sources: the automation an `AudioParam` gives
+ * `process`, and the port messages timestamped for a frame inside the block.
+ * These tests are about the frames -- a step at 40 becoming an event at 40
+ * rather than 0, a `1 -> 0 -> 1` inside one block becoming two edges rather
+ * than none, a message for a later block waiting for it.
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -14,10 +14,10 @@ import { monoProcessor, BLOCK, SAMPLE_RATE } from './harness.mjs';
 const GATE = '/probe/gate';
 const VOL = '/probe/vol';
 
-/** The frames a block's events landed on, which is what these tests are about. */
+/** The frames a block's events landed on. */
 const frames = (events) => events.map((e) => e.frame);
 
-/** A block of automation: `value` from `at` onwards, `from` before it. */
+/** A block of automation: `from` up to frame `at`, `value` from there on. */
 function step(from, value, at) {
     return Array.from({ length: BLOCK }, (_, i) => (i < at ? from : value));
 }
@@ -51,9 +51,9 @@ test('a step inside the block is an event on the frame it happens', () => {
 
 test('1 -> 0 -> 1 inside one block is two edges, not none', () => {
     const p = monoProcessor();
-    // The gate is already up when the block starts, drops at 60 and comes back
-    // at 70. Reading only frame 0 sees 1, compares it to a cached 1, and lets
-    // the whole thing through unnoticed: the hit that never retriggers.
+    // The gate is up when the block starts, drops at 60, returns at 70.
+    // Reading only frame 0 sees 1, matches the cached 1, and misses the drop
+    // entirely -- the hit that never retriggers.
     p.render({ [GATE]: 1 });
     const automation = Array.from({ length: BLOCK }, (_, i) =>
         i >= 60 && i < 70 ? 0 : 1
@@ -68,7 +68,7 @@ test('1 -> 0 -> 1 inside one block is two edges, not none', () => {
 test('a handful of steps in one block are all kept', () => {
     const p = monoProcessor();
     const at = [3, 17, 40, 41, 90, 127];
-    // Starting from 0.5, the control's own default, so frame 0 is not a change.
+    // Starting at 0.5, the control's default, so frame 0 is not a change.
     const automation = Array.from(
         { length: BLOCK },
         (_, i) => 0.5 + at.filter((f) => f <= i).length / 16
@@ -78,9 +78,9 @@ test('a handful of steps in one block are all kept', () => {
 
 test('a ramp is followed coarsely rather than sample by sample', () => {
     const p = monoProcessor();
-    // A `linearRampToValueAtTime` across the block: 128 different values, none
-    // of which is an edge. Writing each one would mean 128 one-frame compute
-    // calls and 128 messages to the main thread, for a slider.
+    // A `linearRampToValueAtTime` across the block: 128 distinct values, no
+    // edges. Honouring each would mean 128 one-frame compute calls and 128
+    // messages to the main thread, for a slider.
     const events = p.render({
         [VOL]: Array.from({ length: BLOCK }, (_, i) => i / BLOCK)
     });
@@ -97,8 +97,8 @@ test('a ramp still leaves the DSP holding the value the block ended on', () => {
     const ramp = Array.from({ length: BLOCK }, (_, i) => i / BLOCK);
     p.render({ [VOL]: ramp });
     assert.equal(p.dsp.writes.at(-1).value, ramp[BLOCK - 1]);
-    // Which is what the next block compares against, so a block that holds
-    // the value the ramp reached has nothing to say.
+    // That is what the next block compares against, so a block holding the
+    // value the ramp reached produces no events.
     assert.deepEqual(p.render({ [VOL]: ramp[BLOCK - 1] }), []);
 });
 
@@ -154,8 +154,8 @@ test('a frame is on the audio clock, not on the block', () => {
     const p = monoProcessor();
     p.render();
     p.render();
-    // Two blocks in, so an absolute frame and a block-relative one are
-    // different numbers and the test says which this is.
+    // Two blocks in, so absolute and block-relative readings differ and this
+    // pins down which one `frame` means.
     assert.equal(p.frame, 2 * BLOCK);
     p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 2 * BLOCK + 77 });
     assert.equal(p.render()[0].frame, 77);
@@ -172,8 +172,8 @@ test('a time that is not a number is refused rather than queued', () => {
     for (const time of [NaN, Infinity, -Infinity, '40', null]) {
         p.port.send({ type: 'keyOn', data: [0, 99, 100], time });
     }
-    // A NaN compares false against every frame, so a queued one would sit at
-    // the head of the queue for ever and hold everything behind it.
+    // A NaN compares false against every frame, so a queued one would stay at
+    // the head of the queue and block everything behind it.
     p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 20 });
     const events = p.render();
     assert.equal(events.length, 1);
@@ -189,9 +189,9 @@ test('two overdue messages are applied in time order, not post order', () => {
     const p = monoProcessor();
     p.render();
     p.render();
-    // Both belong to a block that has gone by, and are posted late and out of
-    // order. They collapse onto frame 0, where only the tie-break can tell
-    // them apart.
+    // Both belong to a block that has passed, and are posted late and out of
+    // order. They collapse onto frame 0, where only the tie-break separates
+    // them.
     p.port.send({ type: 'keyOn', data: [0, 62, 100], frame: 100 });
     p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 10 });
     p.render();
@@ -224,9 +224,9 @@ test('a stop clears what was scheduled for the stretch it stopped', () => {
 
 test('a message that throws costs that message and nothing else', () => {
     const p = monoProcessor();
-    // Per the Web Audio spec, a `process` that throws fires processorerror and
-    // is never called again -- one bad message would silence the node for
-    // good.
+    // Per the Web Audio spec, a `process` that throws fires processorerror
+    // and is never called again, so one bad message would silence the node
+    // permanently.
     p.dsp.keyOn = (channel, pitch) => {
         if (pitch === 99) throw new Error('no such voice');
         p.dsp.notes.push({ type: 'keyOn', channel, pitch });
@@ -315,8 +315,8 @@ test('the events of a block always tile it exactly', () => {
     p.port.send({ type: 'keyOff', data: [0, 60, 0], frame: 60 });
     p.port.send({ type: 'keyOff', data: [0, 62, 0], frame: BLOCK - 1 });
     p.render({ [GATE]: step(0, 1, 60) });
-    // The fake DSP renders through the real `renderBlock`, so this is what the
-    // wasm calls would have been.
+    // The fake DSP goes through the real `renderBlock`, so these are the wasm
+    // calls that would have been made.
     const parts = p.dsp.slices[0];
     assert.deepEqual(parts, [
         [0, 60],
@@ -369,9 +369,9 @@ test('a panic does not cancel the automation around it', () => {
 });
 
 test('only the controllers that silence the instrument flush', () => {
-    // 120 all sound off and 123 all notes off are the two the polyphonic DSP
-    // itself treats as all-notes-off. 121 resets controllers without ending a
-    // note; 122 is local control, which is about a keyboard's own wiring.
+    // 120 (all sound off) and 123 (all notes off) are the two the polyphonic
+    // DSP itself treats as all-notes-off. 121 resets controllers without
+    // ending a note; 122 is a keyboard's local control.
     for (const [ctrl, expected] of [
         [120, []],
         [121, [60]],

--- a/test/unit/timed-events.test.mjs
+++ b/test/unit/timed-events.test.mjs
@@ -14,6 +14,9 @@ import { monoProcessor, BLOCK, SAMPLE_RATE } from './harness.mjs';
 const GATE = '/probe/gate';
 const VOL = '/probe/vol';
 
+/** The frames a block's events landed on, which is what these tests are about. */
+const frames = (events) => events.map((e) => e.frame);
+
 /** A block of automation: `value` from `at` onwards, `from` before it. */
 function step(from, value, at) {
     return Array.from({ length: BLOCK }, (_, i) => (i < at ? from : value));
@@ -28,7 +31,7 @@ test('a block where nothing moves carries no events', () => {
 test('a control that changes between blocks is written once, at frame 0', () => {
     const p = monoProcessor();
     p.render();
-    assert.deepEqual(p.render({ [VOL]: 0.25 }), [{ frame: 0, seq: -1 }]);
+    assert.deepEqual(frames(p.render({ [VOL]: 0.25 })), [0]);
     assert.deepEqual(p.dsp.writes, [{ path: VOL, value: 0.25 }]);
 });
 
@@ -42,8 +45,7 @@ test('a control that holds its new value is not written again', () => {
 
 test('a step inside the block is an event on the frame it happens', () => {
     const p = monoProcessor();
-    const events = p.render({ [GATE]: step(0, 1, 40) });
-    assert.deepEqual(events, [{ frame: 40, seq: -1 }]);
+    assert.deepEqual(frames(p.render({ [GATE]: step(0, 1, 40) })), [40]);
     assert.deepEqual(p.dsp.writes, [{ path: GATE, value: 1 }]);
 });
 
@@ -56,41 +58,48 @@ test('1 -> 0 -> 1 inside one block is two edges, not none', () => {
     const automation = Array.from({ length: BLOCK }, (_, i) =>
         i >= 60 && i < 70 ? 0 : 1
     );
-    assert.deepEqual(p.render({ [GATE]: automation }), [
-        { frame: 60, seq: -1 },
-        { frame: 70, seq: -1 }
-    ]);
+    assert.deepEqual(frames(p.render({ [GATE]: automation })), [60, 70]);
     assert.deepEqual(p.dsp.writes.slice(1), [
         { path: GATE, value: 0 },
         { path: GATE, value: 1 }
     ]);
 });
 
-test('every step of a ramp is its own event', () => {
+test('a handful of steps in one block are all kept', () => {
     const p = monoProcessor();
+    const at = [3, 17, 40, 41, 90, 127];
+    // Starting from 0.5, the control's own default, so frame 0 is not a change.
+    const automation = Array.from(
+        { length: BLOCK },
+        (_, i) => 0.5 + at.filter((f) => f <= i).length / 16
+    );
+    assert.deepEqual(frames(p.render({ [VOL]: automation })), at);
+});
+
+test('a ramp is followed coarsely rather than sample by sample', () => {
+    const p = monoProcessor();
+    // A `linearRampToValueAtTime` across the block: 128 different values, none
+    // of which is an edge. Writing each one would mean 128 one-frame compute
+    // calls and 128 messages to the main thread, for a slider.
     const events = p.render({
         [VOL]: Array.from({ length: BLOCK }, (_, i) => i / BLOCK)
     });
-    assert.equal(events.length, BLOCK);
-    assert.deepEqual(
-        events.map((e) => e.frame),
-        Array.from({ length: BLOCK }, (_, i) => i)
+    assert.ok(
+        events.length < BLOCK / 4,
+        `${events.length} events for a ramp is still a per-sample walk`
     );
-    assert.deepEqual(
-        p.dsp.writes.map((w) => w.value),
-        Array.from({ length: BLOCK }, (_, i) => i / BLOCK)
-    );
+    assert.ok(events.length > 1, 'a ramp is still followed inside the block');
+    assert.equal(events[0].frame, 0);
 });
 
-test('a ramp that starts where the control already is skips frame 0', () => {
+test('a ramp still leaves the DSP holding the value the block ended on', () => {
     const p = monoProcessor();
-    // 0.5 is the control's `init`, which is what the cache was seeded with.
-    const events = p.render({
-        [VOL]: Array.from({ length: BLOCK }, (_, i) => 0.5 + i / 256)
-    });
-    assert.equal(events.length, BLOCK - 1);
-    assert.equal(events[0].frame, 1);
-    assert.equal(events.at(-1).frame, BLOCK - 1);
+    const ramp = Array.from({ length: BLOCK }, (_, i) => i / BLOCK);
+    p.render({ [VOL]: ramp });
+    assert.equal(p.dsp.writes.at(-1).value, ramp[BLOCK - 1]);
+    // Which is what the next block compares against, so a block that holds
+    // the value the ramp reached has nothing to say.
+    assert.deepEqual(p.render({ [VOL]: ramp[BLOCK - 1] }), []);
 });
 
 test('an untimed message is applied on arrival, before the next block', () => {
@@ -141,10 +150,103 @@ test('a message whose block has gone by happens at the top of this one', () => {
     assert.equal(events[0].frame, 0, 'late, not lost');
 });
 
-test('a frame is taken as given, alongside a time in seconds', () => {
+test('a frame is on the audio clock, not on the block', () => {
     const p = monoProcessor();
-    p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 77 });
+    p.render();
+    p.render();
+    // Two blocks in, so an absolute frame and a block-relative one are
+    // different numbers and the test says which this is.
+    assert.equal(p.frame, 2 * BLOCK);
+    p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 2 * BLOCK + 77 });
     assert.equal(p.render()[0].frame, 77);
+});
+
+test('a fractional frame is rounded to a whole one', () => {
+    const p = monoProcessor();
+    p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 40.6 });
+    assert.equal(p.render()[0].frame, 41);
+});
+
+test('a time that is not a number is refused rather than queued', () => {
+    const p = monoProcessor();
+    for (const time of [NaN, Infinity, -Infinity, '40', null]) {
+        p.port.send({ type: 'keyOn', data: [0, 99, 100], time });
+    }
+    // A NaN compares false against every frame, so a queued one would sit at
+    // the head of the queue for ever and hold everything behind it.
+    p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 20 });
+    const events = p.render();
+    assert.equal(events.length, 1);
+    assert.equal(events[0].frame, 20);
+    assert.deepEqual(
+        p.dsp.notes.map((n) => n.pitch),
+        [99, 99, 99, 99, 99, 60],
+        'the unusable timestamps are treated as untimed, and applied on arrival'
+    );
+});
+
+test('two overdue messages are applied in time order, not post order', () => {
+    const p = monoProcessor();
+    p.render();
+    p.render();
+    // Both belong to a block that has gone by, and are posted late and out of
+    // order. They collapse onto frame 0, where only the tie-break can tell
+    // them apart.
+    p.port.send({ type: 'keyOn', data: [0, 62, 100], frame: 100 });
+    p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 10 });
+    p.render();
+    assert.deepEqual(
+        p.dsp.notes.map((n) => n.pitch),
+        [60, 62],
+        'the same order they would have played in if they had been on time'
+    );
+});
+
+test('a panic cancels what has been scheduled and not yet played', () => {
+    const p = monoProcessor();
+    p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 4 * BLOCK });
+    // All notes off, arriving now.
+    p.port.send({ type: 'ctrlChange', data: [0, 123, 0] });
+    for (let i = 0; i < 6; i++) p.render();
+    assert.deepEqual(p.dsp.notes, [], 'the queued note never played');
+    assert.deepEqual(p.dsp.midi, [
+        { type: 'ctrlChange', channel: 0, ctrl: 123, value: 0 }
+    ]);
+});
+
+test('a stop clears what was scheduled for the stretch it stopped', () => {
+    const p = monoProcessor();
+    p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 4 * BLOCK });
+    p.port.send({ type: 'stop' });
+    for (let i = 0; i < 6; i++) p.render();
+    assert.deepEqual(p.dsp.notes, []);
+});
+
+test('a message that throws costs that message and nothing else', () => {
+    const p = monoProcessor();
+    // Per the Web Audio spec, a `process` that throws fires processorerror and
+    // is never called again -- one bad message would silence the node for
+    // good.
+    p.dsp.keyOn = (channel, pitch) => {
+        if (pitch === 99) throw new Error('no such voice');
+        p.dsp.notes.push({ type: 'keyOn', channel, pitch });
+    };
+    const errors = [];
+    const reported = console.error;
+    console.error = (...args) => errors.push(args);
+    try {
+        p.port.send({ type: 'keyOn', data: [0, 99, 100], frame: 10 });
+        p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 20 });
+        assert.doesNotThrow(() => p.render());
+    } finally {
+        console.error = reported;
+    }
+    assert.deepEqual(
+        p.dsp.notes.map((n) => n.pitch),
+        [60],
+        'the message after the bad one still played'
+    );
+    assert.equal(errors.length, 1, 'and the failure was reported');
 });
 
 test('a timed param message is written at its frame', () => {
@@ -185,10 +287,7 @@ test('messages posted out of order are applied in time order', () => {
     p.port.send({ type: 'keyOn', data: [0, 62, 100], time: 90 / SAMPLE_RATE });
     p.port.send({ type: 'keyOn', data: [0, 60, 100], time: 10 / SAMPLE_RATE });
     const events = p.render();
-    assert.deepEqual(
-        events.map((e) => e.frame),
-        [10, 90]
-    );
+    assert.deepEqual(frames(events), [10, 90]);
     assert.deepEqual(
         p.dsp.notes.map((n) => n.pitch),
         [60, 62]
@@ -197,14 +296,16 @@ test('messages posted out of order are applied in time order', () => {
 
 test('automation goes before a message on the same frame', () => {
     const p = monoProcessor();
+    const order = [];
+    p.dsp.setParamValue = () => order.push('automation');
+    p.dsp.keyOn = () => order.push('message');
     p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 40 });
-    const events = p.render({ [GATE]: step(0, 1, 40) });
+    assert.deepEqual(frames(p.render({ [GATE]: step(0, 1, 40) })), [40, 40]);
     assert.deepEqual(
-        events.map((e) => e.frame),
-        [40, 40]
+        order,
+        ['automation', 'message'],
+        'the automation is the state the block starts from'
     );
-    assert.equal(events[0].seq, -1, 'the block starts from the automation');
-    assert.ok(events[1].seq >= 0);
 });
 
 test('the events of a block always tile it exactly', () => {
@@ -233,8 +334,5 @@ test('automation and messages interleave by frame', () => {
     p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 20 });
     p.port.send({ type: 'keyOn', data: [0, 62, 100], frame: 100 });
     const events = p.render({ [GATE]: step(0, 1, 60) });
-    assert.deepEqual(
-        events.map((e) => e.frame),
-        [20, 60, 100]
-    );
+    assert.deepEqual(frames(events), [20, 60, 100]);
 });

--- a/test/unit/timed-events.test.mjs
+++ b/test/unit/timed-events.test.mjs
@@ -336,3 +336,56 @@ test('automation and messages interleave by frame', () => {
     const events = p.render({ [GATE]: step(0, 1, 60) });
     assert.deepEqual(frames(events), [20, 60, 100]);
 });
+
+test('a timed panic cancels the notes later in its own block', () => {
+    const p = monoProcessor();
+    p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 20 });
+    p.port.send({ type: 'ctrlChange', data: [0, 123, 0], frame: 40 });
+    p.port.send({ type: 'keyOn', data: [0, 62, 100], frame: 100 });
+    p.port.send({ type: 'keyOn', data: [0, 64, 100], frame: 3 * BLOCK });
+    p.render();
+    assert.deepEqual(
+        p.dsp.notes.map((n) => n.pitch),
+        [60],
+        'the note before it played, the ones after it did not'
+    );
+    for (let i = 0; i < 4; i++) p.render();
+    assert.deepEqual(
+        p.dsp.notes.map((n) => n.pitch),
+        [60],
+        'and the one in a later block is gone too'
+    );
+});
+
+test('a panic does not cancel the automation around it', () => {
+    const p = monoProcessor();
+    p.port.send({ type: 'ctrlChange', data: [0, 123, 0], frame: 40 });
+    p.render({ [VOL]: step(0.5, 0.25, 90) });
+    assert.deepEqual(
+        p.dsp.writes,
+        [{ path: VOL, value: 0.25 }],
+        'a filter sweep is not a note waiting to sound'
+    );
+});
+
+test('only the controllers that silence the instrument flush', () => {
+    // 120 all sound off and 123 all notes off are the two the polyphonic DSP
+    // itself treats as all-notes-off. 121 resets controllers without ending a
+    // note; 122 is local control, which is about a keyboard's own wiring.
+    for (const [ctrl, expected] of [
+        [120, []],
+        [121, [60]],
+        [122, [60]],
+        [123, []]
+    ]) {
+        const p = monoProcessor();
+        p.port.send({ type: 'ctrlChange', data: [0, ctrl, 0], frame: 10 });
+        p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 50 });
+        p.render();
+        assert.deepEqual(
+            p.dsp.notes.map((n) => n.pitch),
+            expected,
+            `controller ${ctrl}`
+        );
+    }
+});

--- a/test/unit/timed-events.test.mjs
+++ b/test/unit/timed-events.test.mjs
@@ -52,8 +52,6 @@ test('a step inside the block is an event on the frame it happens', () => {
 test('1 -> 0 -> 1 inside one block is two edges, not none', () => {
     const p = monoProcessor();
     // The gate is up when the block starts, drops at 60, returns at 70.
-    // Reading only frame 0 sees 1, matches the cached 1, and misses the drop
-    // entirely -- the hit that never retriggers.
     p.render({ [GATE]: 1 });
     const automation = Array.from({ length: BLOCK }, (_, i) =>
         i >= 60 && i < 70 ? 0 : 1
@@ -78,9 +76,7 @@ test('a handful of steps in one block are all kept', () => {
 
 test('a ramp is followed coarsely rather than sample by sample', () => {
     const p = monoProcessor();
-    // A `linearRampToValueAtTime` across the block: 128 distinct values, no
-    // edges. Honouring each would mean 128 one-frame compute calls and 128
-    // messages to the main thread, for a slider.
+    // A `linearRampToValueAtTime` across the block: 128 distinct values.
     const events = p.render({
         [VOL]: Array.from({ length: BLOCK }, (_, i) => i / BLOCK)
     });
@@ -97,8 +93,7 @@ test('a ramp still leaves the DSP holding the value the block ended on', () => {
     const ramp = Array.from({ length: BLOCK }, (_, i) => i / BLOCK);
     p.render({ [VOL]: ramp });
     assert.equal(p.dsp.writes.at(-1).value, ramp[BLOCK - 1]);
-    // That is what the next block compares against, so a block holding the
-    // value the ramp reached produces no events.
+    // That is what the next block compares against.
     assert.deepEqual(p.render({ [VOL]: ramp[BLOCK - 1] }), []);
 });
 
@@ -154,8 +149,7 @@ test('a frame is on the audio clock, not on the block', () => {
     const p = monoProcessor();
     p.render();
     p.render();
-    // Two blocks in, so absolute and block-relative readings differ and this
-    // pins down which one `frame` means.
+    // Two blocks in, so absolute and block-relative readings differ.
     assert.equal(p.frame, 2 * BLOCK);
     p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 2 * BLOCK + 77 });
     assert.equal(p.render()[0].frame, 77);
@@ -172,8 +166,8 @@ test('a time that is not a number is refused rather than queued', () => {
     for (const time of [NaN, Infinity, -Infinity, '40', null]) {
         p.port.send({ type: 'keyOn', data: [0, 99, 100], time });
     }
-    // A NaN compares false against every frame, so a queued one would stay at
-    // the head of the queue and block everything behind it.
+    // A queued NaN would compare false against every frame and block the
+    // queue behind it.
     p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 20 });
     const events = p.render();
     assert.equal(events.length, 1);
@@ -189,9 +183,8 @@ test('two overdue messages are applied in time order, not post order', () => {
     const p = monoProcessor();
     p.render();
     p.render();
-    // Both belong to a block that has passed, and are posted late and out of
-    // order. They collapse onto frame 0, where only the tie-break separates
-    // them.
+    // Both belong to a block that has passed, posted out of order. They
+    // collapse onto frame 0, where only the tie-break separates them.
     p.port.send({ type: 'keyOn', data: [0, 62, 100], frame: 100 });
     p.port.send({ type: 'keyOn', data: [0, 60, 100], frame: 10 });
     p.render();
@@ -224,9 +217,8 @@ test('a stop clears what was scheduled for the stretch it stopped', () => {
 
 test('a message that throws costs that message and nothing else', () => {
     const p = monoProcessor();
-    // Per the Web Audio spec, a `process` that throws fires processorerror
-    // and is never called again, so one bad message would silence the node
-    // permanently.
+    // A `process` that throws fires processorerror and is never called
+    // again.
     p.dsp.keyOn = (channel, pitch) => {
         if (pitch === 99) throw new Error('no such voice');
         p.dsp.notes.push({ type: 'keyOn', channel, pitch });
@@ -315,8 +307,8 @@ test('the events of a block always tile it exactly', () => {
     p.port.send({ type: 'keyOff', data: [0, 60, 0], frame: 60 });
     p.port.send({ type: 'keyOff', data: [0, 62, 0], frame: BLOCK - 1 });
     p.render({ [GATE]: step(0, 1, 60) });
-    // The fake DSP goes through the real `renderBlock`, so these are the wasm
-    // calls that would have been made.
+    // The fake DSP goes through the real `renderBlock`, so these are the
+    // slices wasm would have been given.
     const parts = p.dsp.slices[0];
     assert.deepEqual(parts, [
         [0, 60],
@@ -390,11 +382,6 @@ test('only the controllers that silence the instrument flush', () => {
     }
 });
 
-// The WAM path had its own way of losing a note: `setupWamEventHandler`
-// installed a handler that called `midiMessage` directly and dropped the
-// event's time, so anything routed through Web Audio Modules landed at the top
-// of whichever block it was processed in -- the scatter this whole branch
-// exists to remove, still there on the one route that was not a port message.
 test('a WAM MIDI event is applied on the frame it carries', () => {
     const p = monoProcessor({ wamInfo: true });
     p.port.send({ type: 'setupWamEventHandler' });

--- a/test/unit/voice-legato.test.mjs
+++ b/test/unit/voice-legato.test.mjs
@@ -1,11 +1,10 @@
 /**
- * The legato split, once a block can be rendered in pieces.
+ * The legato split.
  *
- * `computeLegato` used to be handed 128 and split it in two with `/ 2`. A block
- * rendered in slices hands it whatever the slice is long, odd counts included,
- * and a fractional count reaching wasm is not a rounding error but a different
- * number of frames than the mixer is about to read. The two halves have to add
- * up to what was asked for, whatever it was.
+ * `computeLegato` used to be handed 128 and split it with `/ 2`. It can now be
+ * handed any count, odd ones included, and a fractional count reaching wasm is
+ * not a rounding error -- it is a different number of frames from what the
+ * mixer is about to read. The two halves must add up to what was asked for.
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -14,10 +13,10 @@ import { FaustWebAudioDspVoice } from '../../dist/esm/index.js';
 const GATE = '/probe/gate';
 
 /**
- * A voice whose wasm only writes down what it was asked to do.
+ * A voice whose wasm only records what it was asked to do.
  *
- * One log for both control writes and renders, so the order between them is
- * part of what a test can assert on.
+ * Control writes and renders share one log, so tests can assert on the order
+ * between them.
  */
 function voice() {
     const log = [];
@@ -77,11 +76,11 @@ test('the note being replaced ends before the new one starts', () => {
     const { voice: v, log } = voice();
     v.computeLegato(128, 0, 100, 200);
     assert.deepEqual(log, [
-        // The gate drops, so the first half renders the release of the note
-        // that is going away...
+        // The gate drops, so the first half renders the release of the
+        // outgoing note...
         'gate=0',
         'render:64->100',
-        // ...and the new note is keyed on for the second half.
+        // ...and the new note is keyed on for the second half
         'gate=1',
         'render:64->200'
     ]);

--- a/test/unit/voice-legato.test.mjs
+++ b/test/unit/voice-legato.test.mjs
@@ -1,10 +1,10 @@
 /**
  * The legato split.
  *
- * `computeLegato` used to be handed 128 and split it with `/ 2`. It can now be
- * handed any count, odd ones included, and a fractional count reaching wasm is
- * not a rounding error -- it is a different number of frames from what the
- * mixer is about to read. The two halves must add up to what was asked for.
+ * `computeLegato` can be handed any count, odd ones included. A fractional
+ * count reaching wasm is a different number of frames from what the mixer
+ * reads, so the two halves must be whole and must add up to what was asked
+ * for.
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';

--- a/test/unit/voice-legato.test.mjs
+++ b/test/unit/voice-legato.test.mjs
@@ -1,0 +1,89 @@
+/**
+ * The legato split, once a block can be rendered in pieces.
+ *
+ * `computeLegato` used to be handed 128 and split it in two with `/ 2`. A block
+ * rendered in slices hands it whatever the slice is long, odd counts included,
+ * and a fractional count reaching wasm is not a rounding error but a different
+ * number of frames than the mixer is about to read. The two halves have to add
+ * up to what was asked for, whatever it was.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { FaustWebAudioDspVoice } from '../../dist/esm/index.js';
+
+const GATE = '/probe/gate';
+
+/**
+ * A voice whose wasm only writes down what it was asked to do.
+ *
+ * One log for both control writes and renders, so the order between them is
+ * part of what a test can assert on.
+ */
+function voice() {
+    const log = [];
+    const api = {
+        init: () => {},
+        setParamValue: (dsp, index, value) => log.push(`gate=${value}`),
+        compute: (dsp, count, $inputs, $outputs) =>
+            log.push(`render:${count}->${$outputs}`)
+    };
+    const v = new FaustWebAudioDspVoice(0, api, [GATE], { [GATE]: 0 }, 48000);
+    v.fNextNote = 60;
+    v.fNextVel = 100;
+    log.length = 0;
+    return { voice: v, log };
+}
+
+/** The frame counts of the two renders, in order. */
+const counts = (log) =>
+    log
+        .filter((l) => l.startsWith('render:'))
+        .map((l) => +l.slice(7).split('->')[0]);
+
+test('the two halves add up to the count asked for', () => {
+    for (const count of [128, 127, 64, 63, 3, 2, 1, 0]) {
+        const { voice: v, log } = voice();
+        v.computeLegato(count, 0, 100, 200);
+        const halves = counts(log);
+        assert.equal(halves.length, 2, `${count}: still two halves`);
+        assert.equal(
+            halves[0] + halves[1],
+            count,
+            `${count}: no frame rendered twice, none dropped`
+        );
+        for (const half of halves) {
+            assert.ok(Number.isInteger(half), `${count}: whole frames`);
+            assert.ok(half >= 0, `${count}: no negative count`);
+        }
+    }
+});
+
+test('an odd count gives the extra frame to the second half', () => {
+    const { voice: v, log } = voice();
+    v.computeLegato(127, 0, 100, 200);
+    assert.deepEqual(counts(log), [63, 64]);
+});
+
+test('the first half renders at the slice, the second at the split', () => {
+    const { voice: v, log } = voice();
+    v.computeLegato(128, 0, 100, 200);
+    assert.deepEqual(
+        log.filter((l) => l.startsWith('render:')),
+        ['render:64->100', 'render:64->200']
+    );
+});
+
+test('the note being replaced ends before the new one starts', () => {
+    const { voice: v, log } = voice();
+    v.computeLegato(128, 0, 100, 200);
+    assert.deepEqual(log, [
+        // The gate drops, so the first half renders the release of the note
+        // that is going away...
+        'gate=0',
+        'render:64->100',
+        // ...and the new note is keyed on for the second half.
+        'gate=1',
+        'render:64->200'
+    ]);
+    assert.equal(v.fCurNote, 60);
+});


### PR DESCRIPTION
A JS counterpart to `architecture/faust/dsp/timed-dsp.h`, so a control can take effect on a sample rather than on the 128-frame boundary that follows it.

Motivated by a browser drum machine where sixteenth hats played once a bar. Written up in full at Conceptual-Machines/magda-cloud#99.

## The problem

- `FaustAudioWorkletProcessor.process()` reads `parameters[path][0]` — the first frame of each a-rate AudioParam block — and applies it only when it differs from the cached value. A `gate.setValueAtTime(1, t)` lands on the next block boundary, 0–2.7 ms late at 48 kHz and different for every hit. A `1 → 0 → 1` inside one block is never seen at all, which is a gate that does not retrigger. The comment on the line above already says "possibly needed for sample accurate control".
- `keyOn` / `keyOff` / `param` / `midi` port messages are applied the moment they arrive. No timestamp, no sample offset.
- Both `compute` methods always render `fBufferSize` frames, though the wasm export `compute(dsp, count, ins, outs)` takes a count. `FaustWebAudioDspVoice.computeLegato` already proves sub-block compute with offset pointers works — for one hardcoded split.

## The change

- `FaustTimedEvent` is a frame and a closure. `compute` takes an optional sorted array and renders the block around them; with none it takes the single-slice path every existing caller already takes.
- `renderBlock` drives the slicing in `FaustBaseWebAudioDsp`. `setBufferOffset` points the wasm channel tables at the first frame of each slice, so only the tables move and the channel views stay whole-block. Poly does the same for its mixing tables.
- The processor turns each step in an `AudioParam`'s automation into an event on the frame it happens, and holds a timestamped port message until the block that contains it. An untimed message is applied on arrival, exactly as before.
- `keyOn`, `keyOff`, `ctrlChange`, `pitchWheel`, `midiMessage` and `setParamValue` on the node take an optional `time` in AudioContext seconds — the clock `AudioParam` methods already take. Declared on `IFaustMonoWebAudioNode` / `IFaustPolyWebAudioNode` so it is reachable through what `createFaustNode` returns.
- `setupWamEventHandler` passes a `WamEvent`'s `time` through instead of dropping it.

Nothing is required of an existing caller. Every new argument is optional, and omitting it reproduces the current behaviour.

## Measured

`npm run measure` (test/timing/measure.mjs) compiles `process = button("gate")` with this repo's own libfaust and renders it through a real AudioWorklet in headless Chromium. The rendered signal *is* the gate, so an onset is a sample that went 0 → 1 rather than something a threshold had to be talked into. Sixteen hits 6000 frames apart — 46.875 blocks, so the phase walks through the block.

| | master (0.17.1) | this branch |
|---|---|---|
| gate as an AudioParam | 2 of 16 on the sample, worst 112 frames late | 16 of 16 exact |
| tight `1 → 0 → 1` inside one block | 1 of 16 sounded | 16 of 16 exact |
| timed `keyOn` | no `time` argument to pass | 16 of 16 exact |

`npm run measure -- --runtime <path>` points it at another build to reproduce the left column. Playwright is deliberately **not** added as a dependency — the script imports it lazily and prints what to install, so `npm test` stays browser-free.

`npm test` adds 59 unit tests under `node --test`, no browser and no wasm: the slicing, the automation walk, the event queue and the node's message shapes are arithmetic.

**Regression**: a mono instrument, two effects, a polyphonic instrument and one forced to steal voices all render bit-identically to the published runtime, sample for sample, when no event is timed.

## Known limit: voice stealing

A stolen voice is not sample-accurate, and was not before either. When `keyOn` finds no free voice it marks one `kLegatoVoice`, and the crossfade happens on the *next* `compute`. A timed `keyOn` that steals sounds at the start of the following block rather than on its frame.

Left alone deliberately: landing the steal on its frame would mean crossfading over half of whatever slice it fell in, which late in a block is a fade of one frame or none. So steals are rendered across the whole block *before* the slicing starts, keeping their fixed half-buffer crossfade, and the slices skip those voices. Sample-accurate stealing needs a different crossfade, not a different event queue.

## Notes

- Non-finite and fractional timestamps are rounded or refused rather than queued: a `NaN` compares false against every frame and would sit at the head of the queue with all later events behind it.
- A timed message that throws is caught. It runs from inside `process`, and the spec's answer to a `process` that throws is `processorerror` and never calling the node again.
- A control that changes more than 16 times in a block is a ramp rather than a series of edges, and is followed every 16th change plus the value the block ended on. Every Faust slider is a-rate, so one `linearRampToValueAtTime` would otherwise mean 128 one-frame `compute` calls a block, each re-running the DSP's control section, and 128 `in-param` messages to the main thread.
- CC 120 and 123 (the two `FaustPolyWebAudioDsp.ctrlChange` already treats as all-notes-off), `instanceClear`, `stop` and `destroy` cancel what is scheduled and not yet played. Not the automation — an all-notes-off is not a reason to stop a filter sweep.
- `FaustFFTAudioWorkletProcessor` honours a timestamp at block granularity: it hands its DSP whole frames of spectrum, so a control write partway through what it computes has no meaning. A `param` there still resolves a block after the timestamp, because the per-block `[0]`-against-cache sync writes the pre-`time` value back in the same call; noted in the code.
- Removed as redundant: `FaustPolyAudioWorkletNode.keyOn`/`keyOff`, byte-identical to the base, and the poly processor's re-implementation of the `keyOn`/`keyOff` cases the base switch already dispatches to it.

`npm run build` clean. `tsc --noEmit` adds no errors. `eslint src` count unchanged at 91, all pre-existing. The two prettier hunks remaining in the touched files are pre-existing drift at `master`.

Happy to split this — the AudioParam walk, the sub-block compute and the message queue are separable — or to change the shape if you would rather it looked different.